### PR TITLE
Parsing settings

### DIFF
--- a/src/main/scala/com.gu.gibbons/config/Settings.scala
+++ b/src/main/scala/com.gu.gibbons/config/Settings.scala
@@ -34,15 +34,16 @@ object Settings {
     "ea39a2bb-630d-4565-97ef-a47eff4ec300"
   )
 
-  def fromEnvironment: ValidatedNel[String, Settings] = {
-    val env = System.getenv.asScala.toMap
+  def fromEnvironment: ValidatedNel[String, Settings] =
+    parseEnv(System.getenv.asScala.toMap)
+    
+  def parseEnv(env: Map[String, String]) =
     ( getEnv(env, "AWS_REGION").map(Regions.fromName(_))
     , getEnv(env, "BONOBO_USERS_TABLE")
     , getEnv(env, "SALT")
     , getEnv(env, "BONOBO_URL")
     , getEnv(env, "EMAIL_ORIGIN").map(Email(_))
     ).mapN(Settings(_, _, _, _, _))
-  }
 
   private def getEnv(env: Map[String, String], key: String): ValidatedNel[String, String] =
     env.get(key) match {

--- a/src/main/scala/com.gu.gibbons/lambdas/UserDidNotAnswerLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/UserDidNotAnswerLambda.scala
@@ -1,6 +1,7 @@
 package com.gu.gibbons
 package lambdas
 
+import cats.data.{ Validated, ValidatedNel }
 import cats.syntax.either._
 import com.amazonaws.services.lambda.runtime.Context; 
 import java.time.Instant
@@ -19,42 +20,38 @@ import model.JsonFormats
 import services.interpreters._
 
 class UserDidNotAnswerLambda {
-  import cats.instances.either._
-  import cats.syntax.flatMap._
+  import cats.implicits._
   import JsonFormats._
 
   def handleRequest(is: InputStream, os: OutputStream, context: Context) = {
     go(is).map { program =>
       Await.result(program.runAsync, Duration(context.getRemainingTimeInMillis, MILLISECONDS))
-    } match {
-      case Right(result) => os.write(result.toString.getBytes)
-      case Left(error) => os.write(s"Something went horribly wrong: $error".getBytes)
-    }
+    }.fold(error => os.write(s"Something went horribly wrong: $error".getBytes), result => os.write(result.toString.getBytes))
 
     is.close()
     os.close()
   }
 
-  def go(is: InputStream): Either[String, Task[Json]] = for {
-    settings <- Settings.fromEnvironment
-    dryRun <- readArgs(is)
-  } yield {
-    for {
-      logger <- LoggingInterpreter.apply
-      _ <- logger.info("Hello")
-      _ <- logger.info("Opening up a connection to Bonobo...")
-      bonobo <- BonoboInterpreter(settings, logger)
-      _ <- logger.info("Opening up a connection to SES...")
-      email <- EmailInterpreter(settings, logger)
-      _ <- logger.info("We're all set, starting...")
-      userDidNotAnswer = new UserDidNotAnswer(settings, email, bonobo, logger)
-      rDel <- userDidNotAnswer.run(dryRun)
-      _ <- logger.info("Goodbye")
-    } yield rDel.asJson
-  }
+  def go(is: InputStream): ValidatedNel[String, Task[Json]] = 
+    ( Settings.fromEnvironment
+    , readArgs(is)
+    ).mapN { case (settings, dryRun) => 
+      for {
+        logger <- LoggingInterpreter.apply
+        _ <- logger.info("Hello")
+        _ <- logger.info("Opening up a connection to Bonobo...")
+        bonobo <- BonoboInterpreter(settings, logger)
+        _ <- logger.info("Opening up a connection to SES...")
+        email <- EmailInterpreter(settings, logger)
+        _ <- logger.info("We're all set, starting...")
+        userDidNotAnswer = new UserDidNotAnswer(settings, email, bonobo, logger)
+        rDel <- userDidNotAnswer.run(dryRun)
+        _ <- logger.info("Goodbye")
+      } yield rDel.asJson
+    }
  
-  def readArgs(is: InputStream): Either[String, Boolean] = {
+  def readArgs(is: InputStream): ValidatedNel[String, Boolean] = Validated.fromEither {
     val input = Source.fromInputStream(is).mkString
     decode[Boolean](input).leftMap(_.toString)
-  }
+  }.toValidatedNel
 }

--- a/src/main/scala/com.gu.gibbons/lambdas/UserDidNotAnswerLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/UserDidNotAnswerLambda.scala
@@ -2,7 +2,6 @@ package com.gu.gibbons
 package lambdas
 
 import cats.data.{ Validated, ValidatedNel }
-import cats.syntax.either._
 import com.amazonaws.services.lambda.runtime.Context; 
 import java.time.Instant
 import io.circe.Json

--- a/src/main/scala/com.gu.gibbons/lambdas/UserReminderLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/UserReminderLambda.scala
@@ -1,6 +1,7 @@
 package com.gu.gibbons
 package lambdas
 
+import cats.data.{ Validated, ValidatedNel }
 import cats.syntax.either._
 import com.amazonaws.services.lambda.runtime.Context; 
 import java.time.Instant
@@ -19,42 +20,38 @@ import model.{JsonFormats, Result}
 import services.interpreters._
 
 class UserReminderLambda {
-  import cats.instances.either._
-  import cats.syntax.flatMap._
+  import cats.implicits._
   import JsonFormats._
 
   def handleRequest(is: InputStream, os: OutputStream, context: Context) = {
     go(is).map { program =>
       Await.result(program.runAsync, Duration(context.getRemainingTimeInMillis, MILLISECONDS))
-    } match {
-      case Right(result) => os.write(result.toString.getBytes)
-      case Left(error) => os.write(s"Something went horribly wrong: $error".getBytes)
-    }
+    }.fold(error => os.write(s"Something went horribly wrong: $error".getBytes), result => os.write(result.toString.getBytes))
 
     is.close()
     os.close()
   }
 
-  def go(is: InputStream): Either[String, Task[Json]] = for {
-    settings <- Settings.fromEnvironment
-    dryRun <- readArgs(is)
-  } yield {
-    for {
-      logger <- LoggingInterpreter.apply
-      _ <- logger.info("Hello")
-      _ <- logger.info("Opening up a connection to Bonobo...")
-      bonobo <- BonoboInterpreter(settings, logger)
-      _ <- logger.info("Opening up a connection to SES...")
-      email <- EmailInterpreter(settings, logger)
-      _ <- logger.info("We're all set, starting...")
-      userReminder = new UserReminder(settings, email, bonobo, logger)
-      rRem <- userReminder.run(Instant.now, dryRun)
-      _ <- logger.info("Goodbye")
-    } yield rRem.asJson
-  }
+  def go(is: InputStream): ValidatedNel[String, Task[Json]] = 
+    ( Settings.fromEnvironment
+    , readArgs(is)
+    ).mapN { case (settings, dryRun) => 
+      for {
+        logger <- LoggingInterpreter.apply
+        _ <- logger.info("Hello")
+        _ <- logger.info("Opening up a connection to Bonobo...")
+        bonobo <- BonoboInterpreter(settings, logger)
+        _ <- logger.info("Opening up a connection to SES...")
+        email <- EmailInterpreter(settings, logger)
+        _ <- logger.info("We're all set, starting...")
+        userReminder = new UserReminder(settings, email, bonobo, logger)
+        rRem <- userReminder.run(Instant.now, dryRun)
+        _ <- logger.info("Goodbye")
+      } yield rRem.asJson
+    }
 
-  def readArgs(is: InputStream): Either[String, Boolean] = {
+  def readArgs(is: InputStream): ValidatedNel[String, Boolean] = Validated.fromEither {
     val input = Source.fromInputStream(is).mkString
     decode[Boolean](input).leftMap(_.toString)
-  }
+  }.toValidatedNel
 }

--- a/src/main/scala/com.gu.gibbons/lambdas/UserReminderLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/UserReminderLambda.scala
@@ -2,7 +2,6 @@ package com.gu.gibbons
 package lambdas
 
 import cats.data.{ Validated, ValidatedNel }
-import cats.syntax.either._
 import com.amazonaws.services.lambda.runtime.Context; 
 import java.time.Instant
 import io.circe.parser.decode

--- a/src/test/scala/com.gu.bonobo/config/SettingsSpec.scala
+++ b/src/test/scala/com.gu.bonobo/config/SettingsSpec.scala
@@ -1,0 +1,35 @@
+package com.gu.gibbons.config
+
+import org.scalatest._
+
+class SettingsSpec extends FlatSpec with Matchers with Inspectors {
+  private val validEnv = Map(
+    "AWS_REGION"         -> "eu-west-1",
+    "BONOBO_USERS_TABLE" -> "How",
+    "SALT"               -> "Are",
+    "BONOBO_URL"         -> "You",
+    "EMAIL_ORIGIN"       -> "Doing"
+  )
+
+  private val emptyEnv: Map[String, String] = Map.empty
+
+  "Parsing settings" should "produce a valid settings instance" in {
+    val result = Settings.parseEnv(validEnv)
+    
+    result.isValid should be (true)
+    result.fold(
+      _ => fail("Hmm, Houston, we should have a Settings here"),
+      r => r shouldBe a [Settings]
+    )
+  }
+
+  it should "find all missing keys" in {
+    val result = Settings.parseEnv(emptyEnv)
+
+    result.isValid should be (false)
+    result.fold(
+      es => es.length should be (5),
+      _ => fail("Won't happen")
+    )
+  }
+}

--- a/src/test/scala/com.gu.bonobo/config/SettingsSpec.scala
+++ b/src/test/scala/com.gu.bonobo/config/SettingsSpec.scala
@@ -11,24 +11,42 @@ class SettingsSpec extends FlatSpec with Matchers with Inspectors {
     "EMAIL_ORIGIN"       -> "Doing"
   )
 
+  private val invalidRegion = Map(
+    "AWS_REGION"         -> "Hello",
+    "BONOBO_USERS_TABLE" -> "How",
+    "SALT"               -> "Are",
+    "BONOBO_URL"         -> "You",
+    "EMAIL_ORIGIN"       -> "Doing"
+  )
+
   private val emptyEnv: Map[String, String] = Map.empty
 
   "Parsing settings" should "produce a valid settings instance" in {
     val result = Settings.parseEnv(validEnv)
     
-    result.isValid should be (true)
+    result.isValid shouldBe true
     result.fold(
       _ => fail("Hmm, Houston, we should have a Settings here"),
       r => r shouldBe a [Settings]
     )
   }
 
+  it should "catch invalid region" in {
+    val result = Settings.parseEnv(invalidRegion)
+
+    result.isValid shouldBe false
+    result.fold(
+      es => es.length shouldBe 1,
+      _ => fail("Won't happen")
+    )
+  }
+
   it should "find all missing keys" in {
     val result = Settings.parseEnv(emptyEnv)
 
-    result.isValid should be (false)
+    result.isValid shouldBe false
     result.fold(
-      es => es.length should be (5),
+      es => es.length shouldBe 5,
       _ => fail("Won't happen")
     )
   }


### PR DESCRIPTION
This project provides a good ground to flesh out a few ideas I have around how we should write code moving forward, but with timing constraints I have neglected a few areas and want to set the records straight. First in line is narrowing the trusted code area as much as possible, and it makes sense to start at the end of the world, in particular the program's inputs.

In this PR, the reading of program's settings is made more resilient.

- using applicative style and cats' `ValidatedNel`, we can report all errors at once, if any
- `Regions.fromName` can throw (even though it is not documented), so we make sure to catch that
- unit tests to seal the deal