### PR TITLE
Consolidate resources and lambdas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target
 project/project
-.ensime
+.ensime*
+ensime*
+pc.stdout.log

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -84,7 +84,7 @@ Resources:
                     !Sub ${Stack}/${Stage}/${App}-reminder/${App}.jar
             Description: Lambda for sending email reminders to people owning old keys
             Handler: com.gu.gibbons.lambdas.UserReminderLambda::handleRequest
-            MemorySize: 256
+            MemorySize: 384
             Role: !Sub ${LambdaRole.Arn}
             Runtime: java8
             Timeout: 100
@@ -107,7 +107,7 @@ Resources:
                     !Sub ${Stack}/${Stage}/${App}-cleanup/${App}.jar
             Description: Lambda for cleaning up expired accounts and keys
             Handler: com.gu.gibbons.lambdas.UserDidNotAnswerLambda::handleRequest
-            MemorySize: 256
+            MemorySize: 384
             Role: !Sub ${LambdaRole.Arn}
             Runtime: java8
             Timeout: 100

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -84,7 +84,7 @@ Resources:
                 Key: !Sub ${Stack}/${Stage}/${App}-reminder/${App}.jar
             Description: Lambda for sending email reminders to people owning old keys
             Handler: com.gu.gibbons.lambdas.UserReminderLambda::handleRequest
-            MemorySize: 256
+            MemorySize: 512
             Role: !Sub ${LambdaRole.Arn}
             Runtime: java8
             Timeout: 100
@@ -112,7 +112,7 @@ Resources:
                 Key: !Sub ${Stack}/${Stage}/${App}-cleanup/${App}.jar
             Description: Lambda for cleaning up expired accounts and keys
             Handler: com.gu.gibbons.lambdas.UserDidNotAnswerLambda::handleRequest
-            MemorySize: 256
+            MemorySize: 512
             Role: !Sub ${LambdaRole.Arn}
             Runtime: java8
             Timeout: 100

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -90,10 +90,9 @@ Resources:
             Timeout: 100
             Events:
                 DailyEvent:
-                    Type: Schedule
-                    Properties:
-                        Schedule: cron(30 16 * * ? *)  # Run at 16:30 every day
-                        Input: "true" # this is not a test
+                Type: Schedule
+                Properties:
+                    Schedule: cron(30 16 * * ? *)  # Run at 16:30 every day
         DependsOn: LambdaRole
 
     DidNotAnswerLambda:
@@ -119,9 +118,8 @@ Resources:
             Timeout: 100
             Events:
                 DailyEvent:
-                    Type: Schedule
-                    Properties:
-                        Schedule: cron(30 16 * * ? *)  # Run at 16:30 every day
-                        Input: "true" # this is not a test
+                Type: Schedule
+                Properties:
+                    Schedule: cron(30 16 * * ? *)  # Run at 16:30 every day
         DependsOn: LambdaRole
 

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1,5 +1,4 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Transform: 'AWS::Serverless-2016-10-31'
 Description: Lambdas for handling expired CAPI keys
 Parameters:
     Stack:
@@ -69,7 +68,7 @@ Resources:
                                 StringEquals:
                                     ses:FromAddress: !Ref Origin
     UserReminderLambda:
-        Type: AWS::Serverless::Function
+        Type: AWS::Lambda::Function
         Properties:
             FunctionName:
                 !Sub gibbons-reminder-${Stage}
@@ -79,9 +78,10 @@ Resources:
                     SALT: !Ref Salt
                     BONOBO_URL: !Ref BonoboUrl
                     BONOBO_USERS_TABLE: !Sub bonobo-${Stage}-users
-            CodeUri:
-                Bucket: content-api-dist
-                Key: !Sub ${Stack}/${Stage}/${App}-reminder/${App}.jar
+            Code:
+                S3Bucket: content-api-dist
+                S3Key:
+                    !Sub ${Stack}/${Stage}/${App}-reminder/${App}.jar
             Description: Lambda for sending email reminders to people owning old keys
             Handler: com.gu.gibbons.lambdas.UserReminderLambda::handleRequest
             MemorySize: 512
@@ -97,7 +97,7 @@ Resources:
         DependsOn: LambdaRole
 
     DidNotAnswerLambda:
-        Type: AWS::Serverless::Function
+        Type: AWS::Lambda::Function
         Properties:
             FunctionName:
                 !Sub gibbons-cleanup-${Stage}
@@ -107,9 +107,10 @@ Resources:
                     SALT: !Ref Salt
                     BONOBO_URL: !Ref BonoboUrl
                     BONOBO_USERS_TABLE: !Sub bonobo-${Stage}-users
-            CodeUri:
-                Bucket: content-api-dist
-                Key: !Sub ${Stack}/${Stage}/${App}-cleanup/${App}.jar
+            Code:
+                S3Bucket: content-api-dist
+                S3Key:
+                    !Sub ${Stack}/${Stage}/${App}-cleanup/${App}.jar
             Description: Lambda for cleaning up expired accounts and keys
             Handler: com.gu.gibbons.lambdas.UserDidNotAnswerLambda::handleRequest
             MemorySize: 512

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -84,7 +84,7 @@ Resources:
                     !Sub ${Stack}/${Stage}/${App}-reminder/${App}.jar
             Description: Lambda for sending email reminders to people owning old keys
             Handler: com.gu.gibbons.lambdas.UserReminderLambda::handleRequest
-            MemorySize: 512
+            MemorySize: 256
             Role: !Sub ${LambdaRole.Arn}
             Runtime: java8
             Timeout: 100
@@ -113,7 +113,7 @@ Resources:
                     !Sub ${Stack}/${Stage}/${App}-cleanup/${App}.jar
             Description: Lambda for cleaning up expired accounts and keys
             Handler: com.gu.gibbons.lambdas.UserDidNotAnswerLambda::handleRequest
-            MemorySize: 512
+            MemorySize: 256
             Role: !Sub ${LambdaRole.Arn}
             Runtime: java8
             Timeout: 100

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -1,4 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
+Transform: 'AWS::Serverless-2016-10-31'
 Description: Lambdas for handling expired CAPI keys
 Parameters:
     Stack:
@@ -68,7 +69,7 @@ Resources:
                                 StringEquals:
                                     ses:FromAddress: !Ref Origin
     UserReminderLambda:
-        Type: AWS::Lambda::Function
+        Type: AWS::Serverless::Function
         Properties:
             FunctionName:
                 !Sub gibbons-reminder-${Stage}
@@ -78,10 +79,9 @@ Resources:
                     SALT: !Ref Salt
                     BONOBO_URL: !Ref BonoboUrl
                     BONOBO_USERS_TABLE: !Sub bonobo-${Stage}-users
-            Code:
-                S3Bucket: content-api-dist
-                S3Key:
-                    !Sub ${Stack}/${Stage}/${App}-reminder/${App}.jar
+            CodeUri:
+                Bucket: content-api-dist
+                Key: !Sub ${Stack}/${Stage}/${App}-reminder/${App}.jar
             Description: Lambda for sending email reminders to people owning old keys
             Handler: com.gu.gibbons.lambdas.UserReminderLambda::handleRequest
             MemorySize: 256
@@ -91,7 +91,7 @@ Resources:
         DependsOn: LambdaRole
 
     DidNotAnswerLambda:
-        Type: AWS::Lambda::Function
+        Type: AWS::Serverless::Function
         Properties:
             FunctionName:
                 !Sub gibbons-cleanup-${Stage}
@@ -101,10 +101,9 @@ Resources:
                     SALT: !Ref Salt
                     BONOBO_URL: !Ref BonoboUrl
                     BONOBO_USERS_TABLE: !Sub bonobo-${Stage}-users
-            Code:
-                S3Bucket: content-api-dist
-                S3Key:
-                    !Sub ${Stack}/${Stage}/${App}-cleanup/${App}.jar
+            CodeUri:
+                Bucket: content-api-dist
+                Key: !Sub ${Stack}/${Stage}/${App}-cleanup/${App}.jar
             Description: Lambda for cleaning up expired accounts and keys
             Handler: com.gu.gibbons.lambdas.UserDidNotAnswerLambda::handleRequest
             MemorySize: 256

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -90,9 +90,10 @@ Resources:
             Timeout: 100
             Events:
                 DailyEvent:
-                Type: Schedule
-                Properties:
-                    Schedule: cron(30 16 * * ? *)  # Run at 16:30 every day
+                    Type: Schedule
+                    Properties:
+                        Schedule: cron(30 16 * * ? *)  # Run at 16:30 every day
+                        Input: "true" # this is not a test
         DependsOn: LambdaRole
 
     DidNotAnswerLambda:
@@ -117,8 +118,9 @@ Resources:
             Timeout: 100
             Events:
                 DailyEvent:
-                Type: Schedule
-                Properties:
-                    Schedule: cron(30 16 * * ? *)  # Run at 16:30 every day
+                    Type: Schedule
+                    Properties:
+                        Schedule: cron(30 16 * * ? *)  # Run at 16:30 every day
+                        Input: "true" # this is not a test
         DependsOn: LambdaRole
 

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -88,11 +88,6 @@ Resources:
             Role: !Sub ${LambdaRole.Arn}
             Runtime: java8
             Timeout: 100
-            Events:
-                DailyEvent:
-                Type: Schedule
-                Properties:
-                    Schedule: cron(30 16 * * ? *)  # Run at 16:30 every day
         DependsOn: LambdaRole
 
     DidNotAnswerLambda:
@@ -116,10 +111,5 @@ Resources:
             Role: !Sub ${LambdaRole.Arn}
             Runtime: java8
             Timeout: 100
-            Events:
-                DailyEvent:
-                Type: Schedule
-                Properties:
-                    Schedule: cron(30 16 * * ? *)  # Run at 16:30 every day
         DependsOn: LambdaRole
 

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -87,7 +87,7 @@ Resources:
             MemorySize: 256
             Role: !Sub ${LambdaRole.Arn}
             Runtime: java8
-            Timeout: 300
+            Timeout: 100
         DependsOn: LambdaRole
 
     DidNotAnswerLambda:
@@ -110,6 +110,6 @@ Resources:
             MemorySize: 256
             Role: !Sub ${LambdaRole.Arn}
             Runtime: java8
-            Timeout: 300
+            Timeout: 100
         DependsOn: LambdaRole
 

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -81,7 +81,7 @@ Resources:
             Code:
                 S3Bucket: content-api-dist
                 S3Key:
-                    !Sub ${Stack}/${Stage}/${App}/${App}.jar
+                    !Sub ${Stack}/${Stage}/${App}-reminder/${App}.jar
             Description: Lambda for sending email reminders to people owning old keys
             Handler: com.gu.gibbons.lambdas.UserReminderLambda::handleRequest
             MemorySize: 512
@@ -104,7 +104,7 @@ Resources:
             Code:
                 S3Bucket: content-api-dist
                 S3Key:
-                    !Sub ${Stack}/${Stage}/${App}/${App}.jar
+                    !Sub ${Stack}/${Stage}/${App}-cleanup/${App}.jar
             Description: Lambda for cleaning up expired accounts and keys
             Handler: com.gu.gibbons.lambdas.UserDidNotAnswerLambda::handleRequest
             MemorySize: 512

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -88,6 +88,11 @@ Resources:
             Role: !Sub ${LambdaRole.Arn}
             Runtime: java8
             Timeout: 100
+            Events:
+                DailyEvent:
+                Type: Schedule
+                Properties:
+                    Schedule: cron(30 16 * * ? *)  # Run at 16:30 every day
         DependsOn: LambdaRole
 
     DidNotAnswerLambda:
@@ -110,5 +115,10 @@ Resources:
             Role: !Sub ${LambdaRole.Arn}
             Runtime: java8
             Timeout: 100
+            Events:
+                DailyEvent:
+                Type: Schedule
+                Properties:
+                    Schedule: cron(30 16 * * ? *)  # Run at 16:30 every day
         DependsOn: LambdaRole
 

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -84,7 +84,7 @@ Resources:
                     !Sub ${Stack}/${Stage}/${App}-reminder/${App}.jar
             Description: Lambda for sending email reminders to people owning old keys
             Handler: com.gu.gibbons.lambdas.UserReminderLambda::handleRequest
-            MemorySize: 512
+            MemorySize: 256
             Role: !Sub ${LambdaRole.Arn}
             Runtime: java8
             Timeout: 300
@@ -107,7 +107,7 @@ Resources:
                     !Sub ${Stack}/${Stage}/${App}-cleanup/${App}.jar
             Description: Lambda for cleaning up expired accounts and keys
             Handler: com.gu.gibbons.lambdas.UserDidNotAnswerLambda::handleRequest
-            MemorySize: 512
+            MemorySize: 256
             Role: !Sub ${LambdaRole.Arn}
             Runtime: java8
             Timeout: 300

--- a/src/main/scala/com.gu.gibbons/Script.scala
+++ b/src/main/scala/com.gu.gibbons/Script.scala
@@ -1,0 +1,7 @@
+package com.gu.gibbons
+
+import model.Result
+
+trait Script[F[_]] {
+  def run(dryRun: Boolean): F[Result]
+}

--- a/src/main/scala/com.gu.gibbons/Script.scala
+++ b/src/main/scala/com.gu.gibbons/Script.scala
@@ -1,7 +1,8 @@
 package com.gu.gibbons
 
+import java.time.OffsetDateTime
 import model.Result
 
 trait Script[F[_]] {
-  def run(dryRun: Boolean): F[Result]
+  def run(now: OffsetDateTime, dryRun: Boolean): F[Result]
 }

--- a/src/main/scala/com.gu.gibbons/UserDidNotAnswer.scala
+++ b/src/main/scala/com.gu.gibbons/UserDidNotAnswer.scala
@@ -14,7 +14,7 @@ import services._
   * @param bonobo The bonobo service interpreter
   * @param logger The logging service interpreter
   */
-class UserDidNotAnswer[F[_] : Monad](settings: Settings, email: EmailService[F], bonobo: BonoboService[F], logger: LoggingService[F]) {
+class UserDidNotAnswer[F[_] : Monad](settings: Settings, email: EmailService[F], bonobo: BonoboService[F], logger: LoggingService[F]) extends Script[F] {
     import cats.instances.vector._
     import cats.syntax.functor._
     import cats.syntax.flatMap._

--- a/src/main/scala/com.gu.gibbons/UserDidNotAnswer.scala
+++ b/src/main/scala/com.gu.gibbons/UserDidNotAnswer.scala
@@ -37,7 +37,7 @@ class UserDidNotAnswer[F[_] : Monad](settings: Settings, email: EmailService[F],
           _ <- logger.info(s"Getting all the users which have not extended their account since ${Settings.gracePeriod}")
           users <- bonobo.getInactiveUsers(Settings.gracePeriod)
           _ <- logger.info(s"Found ${users.length} users. Let's delete these keys...")
-          ress <- users.traverse { user =>
+          ress <- users.filterNot(u => Settings.whitelist(u.id.id)).traverse { user =>
             for {
               _ <- bonobo.deleteUser(user)
               res <- email.sendDeleted(user)

--- a/src/main/scala/com.gu.gibbons/UserReminder.scala
+++ b/src/main/scala/com.gu.gibbons/UserReminder.scala
@@ -2,9 +2,8 @@ package com.gu.gibbons
 
 // ------------------------------------------------------------------------
 import cats.Monad
-import cats.effect.Effect
 import config.Settings
-import java.time.Instant
+import java.time.OffsetDateTime
 import model._
 import services._
 // ------------------------------------------------------------------------
@@ -15,7 +14,7 @@ import services._
   * @param bonobo The bonobo service interpreter
   * @param logger The logging service interpreter
   */
-class UserReminder[F[_] : Monad : Effect](settings: Settings, email: EmailService[F], bonobo: BonoboService[F], logger: LoggingService[F]) extends Script[F] {
+class UserReminder[F[_] : Monad](settings: Settings, email: EmailService[F], bonobo: BonoboService[F], logger: LoggingService[F]) extends Script[F] {
     import cats.instances.vector._
     import cats.instances.map._
     import cats.syntax.flatMap._
@@ -28,25 +27,28 @@ class UserReminder[F[_] : Monad : Effect](settings: Settings, email: EmailServic
       * 3- Sends a reminder email to each user 
       * 4- Update keys to log when a reminder has been sent
       */
-    def run(dryRun: Boolean): F[Result] = 
+    def run(now: OffsetDateTime, dryRun: Boolean): F[Result] = {
+      val fromBefore = now.minus(Settings.inactivityPeriod).toInstant
+      
       if (dryRun) 
         for {
           _ <- logger.info("Yop, who's up for receiving a reminder?")
-          users <- bonobo.getUsers(Settings.inactivityPeriod)
+          users <- bonobo.getUsers(fromBefore)
         } yield DryRun(users)
       else
         for {
           _ <- logger.info(s"Getting all the users older than ${Settings.inactivityPeriod}")
-          users <- bonobo.getUsers(Settings.inactivityPeriod)
+          users <- bonobo.getUsers(fromBefore)
           _ <- logger.info(s"Found ${users.length} users. Let's send some emails...")
-          now <- implicitly[Effect[F]].delay { Instant.now }
+          nowI = now.toInstant
           ress <- users.filterNot(u => Settings.whitelist(u.id.id)).traverse { user => 
             for {
-              newUser <- bonobo.setRemindedOn(user, now)
+              newUser <- bonobo.setRemindedOn(user, nowI)
               res <- email.sendReminder(newUser)
             } yield (newUser.id -> res)
           }.map(_.toMap)
           _ <- logger.info("aaaand that's a wrap! See you next time.")
         } yield FullRun(ress)
+    }
 }
 

--- a/src/main/scala/com.gu.gibbons/UserReminder.scala
+++ b/src/main/scala/com.gu.gibbons/UserReminder.scala
@@ -38,7 +38,7 @@ class UserReminder[F[_] : Monad](settings: Settings, email: EmailService[F], bon
           _ <- logger.info(s"Getting all the users older than ${Settings.inactivityPeriod}")
           users <- bonobo.getUsers(Settings.inactivityPeriod)
           _ <- logger.info(s"Found ${users.length} users. Let's send some emails...")
-          ress <- users.traverse { user => 
+          ress <- users.filterNot(u => Settings.whitelist(u.id.id)).traverse { user => 
             for {
               newUser <- bonobo.setRemindedOn(user, now)
               res <- email.sendReminder(newUser)

--- a/src/main/scala/com.gu.gibbons/UserReminder.scala
+++ b/src/main/scala/com.gu.gibbons/UserReminder.scala
@@ -40,9 +40,9 @@ class UserReminder[F[_] : Monad](settings: Settings, email: EmailService[F], bon
           _ <- logger.info(s"Found ${users.length} users. Let's send some emails...")
           ress <- users.traverse { user => 
             for {
-              res <- email.sendReminder(user)
-              _ <- bonobo.setRemindedOn(user, now)
-            } yield (user.id -> res)
+              newUser <- bonobo.setRemindedOn(user, now)
+              res <- email.sendReminder(newUser)
+            } yield (newUser.id -> res)
           }.map(_.toMap)
           _ <- logger.info("aaaand that's a wrap! See you next time.")
         } yield FullRun(ress)

--- a/src/main/scala/com.gu.gibbons/config/Settings.scala
+++ b/src/main/scala/com.gu.gibbons/config/Settings.scala
@@ -16,7 +16,15 @@ case class Settings(
   usersTableName: String,
   salt: String,
   bonoboUrl: String,
-  fromAddress: Email
+  fromAddress: Email,
+  httpSettings: HttpSettings
+)
+
+case class HttpSettings(
+  connectionTimeout: Int,
+  readTimeout: Int,
+  idleConnections: Int,
+  keepAlive: Int
 )
 
 object Settings {
@@ -44,7 +52,7 @@ object Settings {
     , getEnv(env, "SALT")
     , getEnv(env, "BONOBO_URL")
     , getEnv(env, "EMAIL_ORIGIN").map(Email(_))
-    ).mapN(Settings(_, _, _, _, _))
+    ).mapN(Settings(_, _, _, _, _, HttpSettings(1, 1, 5, 10)))
 
   private def makeRegion(r: String): ValidatedNel[String, Regions] = Validated.fromTry {
     Try(Regions.fromName(r))

--- a/src/main/scala/com.gu.gibbons/config/Settings.scala
+++ b/src/main/scala/com.gu.gibbons/config/Settings.scala
@@ -22,6 +22,15 @@ object Settings {
   val reminderSubject = "Your Content API keys are about to expire"
   val deletedSubject = "Your Content API keys have been deleted"
 
+  /** These accounts belong to the Guardian digital department and can
+    *  safely be ignored
+    */
+  val whitelist = Set(
+    "e3e345ef-b366-4641-c634-1228b1b9ff9a",
+    "7d8f16ba-b57b-491e-91cf-d9a9d1431ccf",
+    "10f1ba90-838e-4bc2-aa56-c084011012e6"
+  )
+
   def fromEnvironment: Either[String, Settings] = {
     val env = System.getenv.asScala.toMap
     for{

--- a/src/main/scala/com.gu.gibbons/config/Settings.scala
+++ b/src/main/scala/com.gu.gibbons/config/Settings.scala
@@ -28,7 +28,8 @@ object Settings {
   val whitelist = Set(
     "e3e345ef-b366-4641-c634-1228b1b9ff9a",
     "7d8f16ba-b57b-491e-91cf-d9a9d1431ccf",
-    "10f1ba90-838e-4bc2-aa56-c084011012e6"
+    "10f1ba90-838e-4bc2-aa56-c084011012e6",
+    "ea39a2bb-630d-4565-97ef-a47eff4ec300"
   )
 
   def fromEnvironment: Either[String, Settings] = {

--- a/src/main/scala/com.gu.gibbons/lambdas/GenericLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/GenericLambda.scala
@@ -2,14 +2,18 @@ package com.gu.gibbons
 package lambdas
 
 import cats.data.{ Validated, ValidatedNel }
+import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBAsyncClientBuilder, AmazonDynamoDBAsync}
 import com.amazonaws.services.lambda.runtime.Context; 
+import com.amazonaws.services.simpleemail.{AmazonSimpleEmailServiceAsyncClientBuilder, AmazonSimpleEmailServiceAsync}
 import java.time.Instant
 import io.circe.Json
 import io.circe.parser.decode
 import io.circe.syntax._
 import java.io.{InputStream, OutputStream}
+import java.util.concurrent.TimeUnit
 import monix.execution.Scheduler.Implicits.global
 import monix.eval.Task
+import okhttp3._
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 import scala.io.Source
@@ -24,7 +28,12 @@ abstract class GenericLambda(implicit ec: ExecutionContext) {
   def handleRequest(is: InputStream, os: OutputStream, context: Context) = {
     ( Settings.fromEnvironment
     , readArgs(is)
-    ).mapN(go).map { program =>
+    ).mapN { case (settings: Settings, dryRun: Boolean) =>
+      for {
+        logger <- LoggingInterpreter(this.getClass.toString)
+        _ <- resources(settings, logger).bracket(go(_, logger, settings, dryRun))(cleanup _)
+      } yield ()
+    }.map { program =>
       Await.result(program.runAsync, Duration(context.getRemainingTimeInMillis, MILLISECONDS))
     }.fold(
       error => os.write(s"Something went horribly wrong: $error".getBytes), 
@@ -35,10 +44,40 @@ abstract class GenericLambda(implicit ec: ExecutionContext) {
     os.close()
   }
 
-  def go(settings: Settings, dryRun: Boolean): Task[Json]
+  def go(resources: Resources, logger: LoggingInterpreter, settings: Settings, dryRun: Boolean): Task[Json]
  
   private def readArgs(is: InputStream): ValidatedNel[String, Boolean] = Validated.fromEither {
     val input = Source.fromInputStream(is).mkString
     decode[Boolean](input).leftMap(_.toString)
   }.toValidatedNel
+
+  private def resources(settings: Settings, logger: LoggingInterpreter): Task[Resources] = Task.evalOnce {
+    val emailClient = AmazonSimpleEmailServiceAsyncClientBuilder.standard()
+      .withRegion(settings.region)
+      .build()
+
+    val dynamoClient = AmazonDynamoDBAsyncClientBuilder.standard()
+      .withRegion(settings.region)
+      .build()
+
+    val httpClient = new OkHttpClient.Builder()
+      .connectTimeout(1, TimeUnit.SECONDS)
+      .readTimeout(1, TimeUnit.SECONDS)
+      .connectionPool(new ConnectionPool(5, 10, TimeUnit.SECONDS))
+      .build
+
+    Resources(emailClient, dynamoClient, httpClient)
+  }.attempt.flatMap {
+    case Left(error) => 
+      logger.error(s"Failed to initialize resources: $error") >>= (_ => Task.raiseError(error))
+    case Right(success) => Task.now(success)
+  }
+
+  private def cleanup(res: Resources): Task[Unit] = Task.eval {
+    res.email.shutdown()
+    res.dynamo.shutdown()
+    res.http.dispatcher.executorService.shutdown()
+  }
+
+  protected case class Resources(email: AmazonSimpleEmailServiceAsync, dynamo: AmazonDynamoDBAsync, http: OkHttpClient)
 }

--- a/src/main/scala/com.gu.gibbons/lambdas/GenericLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/GenericLambda.scala
@@ -2,24 +2,20 @@ package com.gu.gibbons
 package lambdas
 
 import cats.data.{ Validated, ValidatedNel }
-import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBAsyncClientBuilder, AmazonDynamoDBAsync}
 import com.amazonaws.services.lambda.runtime.Context; 
-import com.amazonaws.services.simpleemail.{AmazonSimpleEmailServiceAsyncClientBuilder, AmazonSimpleEmailServiceAsync}
 import io.circe.Json
 import io.circe.parser.decode
 import java.io.{InputStream, OutputStream}
-import java.util.concurrent.TimeUnit
 import monix.eval.Task
 import monix.execution.Scheduler
-import okhttp3.{OkHttpClient, ConnectionPool}
-import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.io.Source
 
 import config._
 import services.interpreters._
 
-abstract class GenericLambda(implicit sched: Scheduler) {
+abstract class GenericLambda(implicit sched: Scheduler) extends ResourceProvider {
   import cats.implicits._
 
   def handleRequest(is: InputStream, os: OutputStream, context: Context) = {
@@ -47,34 +43,4 @@ abstract class GenericLambda(implicit sched: Scheduler) {
     val input = Source.fromInputStream(is).mkString
     decode[Boolean](input).leftMap(_.toString)
   }.toValidatedNel
-
-  private def resources(settings: Settings, logger: LoggingInterpreter): Task[Resources] = Task.evalOnce {
-    val emailClient = AmazonSimpleEmailServiceAsyncClientBuilder.standard()
-      .withRegion(settings.region)
-      .build()
-
-    val dynamoClient = AmazonDynamoDBAsyncClientBuilder.standard()
-      .withRegion(settings.region)
-      .build()
-
-    val httpClient = new OkHttpClient.Builder()
-      .connectTimeout(1, TimeUnit.SECONDS)
-      .readTimeout(1, TimeUnit.SECONDS)
-      .connectionPool(new ConnectionPool(5, 10, TimeUnit.SECONDS))
-      .build
-
-    Resources(emailClient, dynamoClient, httpClient)
-  }.attempt.flatMap {
-    case Left(error) => 
-      logger.error(s"Failed to initialize resources: $error") >>= (_ => Task.raiseError(error))
-    case Right(success) => Task.now(success)
-  }
-
-  private def cleanup(res: Resources): Task[Unit] = Task.eval {
-    res.email.shutdown()
-    res.dynamo.shutdown()
-    res.http.dispatcher.executorService.shutdown()
-  }
-
-  protected case class Resources(email: AmazonSimpleEmailServiceAsync, dynamo: AmazonDynamoDBAsync, http: OkHttpClient)
 }

--- a/src/main/scala/com.gu.gibbons/lambdas/GenericLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/GenericLambda.scala
@@ -5,24 +5,21 @@ import cats.data.{ Validated, ValidatedNel }
 import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBAsyncClientBuilder, AmazonDynamoDBAsync}
 import com.amazonaws.services.lambda.runtime.Context; 
 import com.amazonaws.services.simpleemail.{AmazonSimpleEmailServiceAsyncClientBuilder, AmazonSimpleEmailServiceAsync}
-import java.time.Instant
 import io.circe.Json
 import io.circe.parser.decode
-import io.circe.syntax._
 import java.io.{InputStream, OutputStream}
 import java.util.concurrent.TimeUnit
-import monix.execution.Scheduler.Implicits.global
 import monix.eval.Task
-import okhttp3._
+import monix.execution.Scheduler
+import okhttp3.{OkHttpClient, ConnectionPool}
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 import scala.io.Source
 
 import config._
-import model.JsonFormats
 import services.interpreters._
 
-abstract class GenericLambda(implicit ec: ExecutionContext) {
+abstract class GenericLambda(implicit sched: Scheduler) {
   import cats.implicits._
 
   def handleRequest(is: InputStream, os: OutputStream, context: Context) = {

--- a/src/main/scala/com.gu.gibbons/lambdas/GenericLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/GenericLambda.scala
@@ -1,0 +1,44 @@
+package com.gu.gibbons
+package lambdas
+
+import cats.data.{ Validated, ValidatedNel }
+import com.amazonaws.services.lambda.runtime.Context; 
+import java.time.Instant
+import io.circe.Json
+import io.circe.parser.decode
+import io.circe.syntax._
+import java.io.{InputStream, OutputStream}
+import monix.execution.Scheduler.Implicits.global
+import monix.eval.Task
+import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.duration._
+import scala.io.Source
+
+import config._
+import model.JsonFormats
+import services.interpreters._
+
+abstract class GenericLambda(implicit ec: ExecutionContext) {
+  import cats.implicits._
+
+  def handleRequest(is: InputStream, os: OutputStream, context: Context) = {
+    ( Settings.fromEnvironment
+    , readArgs(is)
+    ).mapN(go).map { program =>
+      Await.result(program.runAsync, Duration(context.getRemainingTimeInMillis, MILLISECONDS))
+    }.fold(
+      error => os.write(s"Something went horribly wrong: $error".getBytes), 
+      result => os.write(result.toString.getBytes)
+    )
+
+    is.close()
+    os.close()
+  }
+
+  def go(settings: Settings, dryRun: Boolean): Task[Json]
+ 
+  private def readArgs(is: InputStream): ValidatedNel[String, Boolean] = Validated.fromEither {
+    val input = Source.fromInputStream(is).mkString
+    decode[Boolean](input).leftMap(_.toString)
+  }.toValidatedNel
+}

--- a/src/main/scala/com.gu.gibbons/lambdas/ResourceProvider.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/ResourceProvider.scala
@@ -21,9 +21,12 @@ trait ResourceProvider {
       .build()
 
     val httpClient = new OkHttpClient.Builder()
-      .connectTimeout(1, TimeUnit.SECONDS)
-      .readTimeout(1, TimeUnit.SECONDS)
-      .connectionPool(new ConnectionPool(5, 10, TimeUnit.SECONDS))
+      .connectTimeout(settings.httpSettings.connectionTimeout, TimeUnit.SECONDS)
+      .readTimeout(settings.httpSettings.readTimeout, TimeUnit.SECONDS)
+      .connectionPool(new ConnectionPool(
+        settings.httpSettings.idleConnections, 
+        settings.httpSettings.keepAlive, 
+        TimeUnit.SECONDS))
       .build
 
     val urlGenerator = UrlGenerator(settings)

--- a/src/main/scala/com.gu.gibbons/lambdas/ResourceProvider.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/ResourceProvider.scala
@@ -1,0 +1,42 @@
+package com.gu.gibbons.lambdas
+
+import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBAsyncClientBuilder, AmazonDynamoDBAsync}
+import com.amazonaws.services.simpleemail.{AmazonSimpleEmailServiceAsyncClientBuilder, AmazonSimpleEmailServiceAsync}
+import com.gu.gibbons.config.Settings
+import com.gu.gibbons.services.interpreters.LoggingInterpreter
+import java.util.concurrent.TimeUnit
+import monix.eval.Task
+import okhttp3.{OkHttpClient, ConnectionPool}
+
+
+trait ResourceProvider {
+  def resources(settings: Settings, logger: LoggingInterpreter): Task[Resources] = Task.evalOnce {
+    val emailClient = AmazonSimpleEmailServiceAsyncClientBuilder.standard()
+      .withRegion(settings.region)
+      .build()
+
+    val dynamoClient = AmazonDynamoDBAsyncClientBuilder.standard()
+      .withRegion(settings.region)
+      .build()
+
+    val httpClient = new OkHttpClient.Builder()
+      .connectTimeout(1, TimeUnit.SECONDS)
+      .readTimeout(1, TimeUnit.SECONDS)
+      .connectionPool(new ConnectionPool(5, 10, TimeUnit.SECONDS))
+      .build
+
+    Resources(emailClient, dynamoClient, httpClient)
+  }.attempt.flatMap {
+    case Left(error) => 
+      logger.error(s"Failed to initialize resources: $error").flatMap(_ => Task.raiseError(error))
+    case Right(success) => Task.now(success)
+  }
+
+  def cleanup(res: Resources): Task[Unit] = Task.eval {
+    res.email.shutdown()
+    res.dynamo.shutdown()
+    res.http.dispatcher.executorService.shutdown()
+  }
+
+  case class Resources(email: AmazonSimpleEmailServiceAsync, dynamo: AmazonDynamoDBAsync, http: OkHttpClient)
+}

--- a/src/main/scala/com.gu.gibbons/lambdas/UserDidNotAnswerLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/UserDidNotAnswerLambda.scala
@@ -48,7 +48,7 @@ class UserDidNotAnswerLambda {
       email <- EmailInterpreter(settings, logger)
       _ <- logger.info("We're all set, starting...")
       userDidNotAnswer = new UserDidNotAnswer(settings, email, bonobo, logger)
-      rDel <- userDidNotAnswer.run(true)
+      rDel <- userDidNotAnswer.run(dryRun)
       _ <- logger.info("Goodbye")
     } yield rDel.asJson
   }

--- a/src/main/scala/com.gu.gibbons/lambdas/UserDidNotAnswerLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/UserDidNotAnswerLambda.scala
@@ -1,56 +1,28 @@
 package com.gu.gibbons
 package lambdas
 
-import cats.data.{ Validated, ValidatedNel }
-import com.amazonaws.services.lambda.runtime.Context; 
-import java.time.Instant
-import io.circe.Json
-import io.circe.parser.decode
 import io.circe.syntax._
-import java.io.{InputStream, OutputStream}
+import java.time.Instant
 import monix.execution.Scheduler.Implicits.global
-import monix.eval.Task
-import scala.concurrent.Await
-import scala.concurrent.duration._
-import scala.io.Source
 
 import config._
 import model.JsonFormats
 import services.interpreters._
 
-class UserDidNotAnswerLambda {
-  import cats.implicits._
+class UserDidNotAnswerLambda extends GenericLambda {
   import JsonFormats._
 
-  def handleRequest(is: InputStream, os: OutputStream, context: Context) = {
-    go(is).map { program =>
-      Await.result(program.runAsync, Duration(context.getRemainingTimeInMillis, MILLISECONDS))
-    }.fold(error => os.write(s"Something went horribly wrong: $error".getBytes), result => os.write(result.toString.getBytes))
-
-    is.close()
-    os.close()
-  }
-
-  def go(is: InputStream): ValidatedNel[String, Task[Json]] = 
-    ( Settings.fromEnvironment
-    , readArgs(is)
-    ).mapN { case (settings, dryRun) => 
-      for {
-        logger <- LoggingInterpreter.apply
-        _ <- logger.info("Hello")
-        _ <- logger.info("Opening up a connection to Bonobo...")
-        bonobo <- BonoboInterpreter(settings, logger)
-        _ <- logger.info("Opening up a connection to SES...")
-        email <- EmailInterpreter(settings, logger)
-        _ <- logger.info("We're all set, starting...")
-        userDidNotAnswer = new UserDidNotAnswer(settings, email, bonobo, logger)
-        rDel <- userDidNotAnswer.run(dryRun)
-        _ <- logger.info("Goodbye")
-      } yield rDel.asJson
-    }
- 
-  def readArgs(is: InputStream): ValidatedNel[String, Boolean] = Validated.fromEither {
-    val input = Source.fromInputStream(is).mkString
-    decode[Boolean](input).leftMap(_.toString)
-  }.toValidatedNel
+  override def go(settings: Settings, dryRun: Boolean) = 
+    for {
+      logger <- LoggingInterpreter.apply
+      _ <- logger.info("Hello")
+      _ <- logger.info("Opening up a connection to Bonobo...")
+      bonobo <- BonoboInterpreter(settings, logger)
+      _ <- logger.info("Opening up a connection to SES...")
+      email <- EmailInterpreter(settings, logger)
+      _ <- logger.info("We're all set, starting...")
+      userDidNotAnswer = new UserDidNotAnswer(settings, email, bonobo, logger)
+      rDel <- userDidNotAnswer.run(dryRun)
+      _ <- logger.info("Goodbye")
+    } yield rDel.asJson
 }

--- a/src/main/scala/com.gu.gibbons/lambdas/UserDidNotAnswerLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/UserDidNotAnswerLambda.scala
@@ -1,22 +1,6 @@
 package com.gu.gibbons
 package lambdas
 
-import io.circe.syntax._
-import java.time.Instant
 import monix.execution.Scheduler.Implicits.global
 
-import config._
-import model.JsonFormats
-import services.interpreters._
-
-class UserDidNotAnswerLambda extends GenericLambda {
-  import JsonFormats._
-
-  override def go(resources: Resources, logger: LoggingInterpreter, settings: Settings, dryRun: Boolean) = {
-    val bonobo = new BonoboInterpreter(settings, logger, resources.dynamo, resources.http, resources.url)
-    val email = new EmailInterpreter(settings, logger, resources.email, resources.url)
-    val userDidNotAnswer = new UserDidNotAnswer(settings, email, bonobo, logger)
-    
-    userDidNotAnswer.run(dryRun).map(_.asJson)
-  }
-}
+class UserDidNotAnswerLambda extends GenericLambda(new UserDidNotAnswer(_, _, _, _))

--- a/src/main/scala/com.gu.gibbons/lambdas/UserDidNotAnswerLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/UserDidNotAnswerLambda.scala
@@ -13,8 +13,8 @@ class UserDidNotAnswerLambda extends GenericLambda {
   import JsonFormats._
 
   override def go(resources: Resources, logger: LoggingInterpreter, settings: Settings, dryRun: Boolean) = {
-    val bonobo = new BonoboInterpreter(settings, logger, resources.dynamo, resources.http)
-    val email = new EmailInterpreter(settings, logger, resources.email)
+    val bonobo = new BonoboInterpreter(settings, logger, resources.dynamo, resources.http, resources.url)
+    val email = new EmailInterpreter(settings, logger, resources.email, resources.url)
     
     for {
       _ <- logger.info("Hello")

--- a/src/main/scala/com.gu.gibbons/lambdas/UserDidNotAnswerLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/UserDidNotAnswerLambda.scala
@@ -12,17 +12,15 @@ import services.interpreters._
 class UserDidNotAnswerLambda extends GenericLambda {
   import JsonFormats._
 
-  override def go(settings: Settings, dryRun: Boolean) = 
+  override def go(resources: Resources, logger: LoggingInterpreter, settings: Settings, dryRun: Boolean) = {
+    val bonobo = new BonoboInterpreter(settings, logger, resources.dynamo, resources.http)
+    val email = new EmailInterpreter(settings, logger, resources.email)
+    
     for {
-      logger <- LoggingInterpreter.apply
       _ <- logger.info("Hello")
-      _ <- logger.info("Opening up a connection to Bonobo...")
-      bonobo <- BonoboInterpreter(settings, logger)
-      _ <- logger.info("Opening up a connection to SES...")
-      email <- EmailInterpreter(settings, logger)
-      _ <- logger.info("We're all set, starting...")
       userDidNotAnswer = new UserDidNotAnswer(settings, email, bonobo, logger)
       rDel <- userDidNotAnswer.run(dryRun)
       _ <- logger.info("Goodbye")
     } yield rDel.asJson
+  }
 }

--- a/src/main/scala/com.gu.gibbons/lambdas/UserDidNotAnswerLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/UserDidNotAnswerLambda.scala
@@ -15,12 +15,8 @@ class UserDidNotAnswerLambda extends GenericLambda {
   override def go(resources: Resources, logger: LoggingInterpreter, settings: Settings, dryRun: Boolean) = {
     val bonobo = new BonoboInterpreter(settings, logger, resources.dynamo, resources.http, resources.url)
     val email = new EmailInterpreter(settings, logger, resources.email, resources.url)
+    val userDidNotAnswer = new UserDidNotAnswer(settings, email, bonobo, logger)
     
-    for {
-      _ <- logger.info("Hello")
-      userDidNotAnswer = new UserDidNotAnswer(settings, email, bonobo, logger)
-      rDel <- userDidNotAnswer.run(dryRun)
-      _ <- logger.info("Goodbye")
-    } yield rDel.asJson
+    userDidNotAnswer.run(dryRun).map(_.asJson)
   }
 }

--- a/src/main/scala/com.gu.gibbons/lambdas/UserReminderLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/UserReminderLambda.scala
@@ -1,56 +1,28 @@
 package com.gu.gibbons
 package lambdas
 
-import cats.data.{ Validated, ValidatedNel }
-import com.amazonaws.services.lambda.runtime.Context; 
-import java.time.Instant
-import io.circe.parser.decode
 import io.circe.syntax._
-import io.circe.Json
-import java.io.{InputStream, OutputStream}
+import java.time.Instant
 import monix.execution.Scheduler.Implicits.global
-import monix.eval.Task
-import scala.concurrent.Await
-import scala.concurrent.duration._
-import scala.io.Source
 
 import config._
 import model.{JsonFormats, Result}
 import services.interpreters._
 
-class UserReminderLambda {
-  import cats.implicits._
+class UserReminderLambda extends GenericLambda {
   import JsonFormats._
 
-  def handleRequest(is: InputStream, os: OutputStream, context: Context) = {
-    go(is).map { program =>
-      Await.result(program.runAsync, Duration(context.getRemainingTimeInMillis, MILLISECONDS))
-    }.fold(error => os.write(s"Something went horribly wrong: $error".getBytes), result => os.write(result.toString.getBytes))
-
-    is.close()
-    os.close()
-  }
-
-  def go(is: InputStream): ValidatedNel[String, Task[Json]] = 
-    ( Settings.fromEnvironment
-    , readArgs(is)
-    ).mapN { case (settings, dryRun) => 
-      for {
-        logger <- LoggingInterpreter.apply
-        _ <- logger.info("Hello")
-        _ <- logger.info("Opening up a connection to Bonobo...")
-        bonobo <- BonoboInterpreter(settings, logger)
-        _ <- logger.info("Opening up a connection to SES...")
-        email <- EmailInterpreter(settings, logger)
-        _ <- logger.info("We're all set, starting...")
-        userReminder = new UserReminder(settings, email, bonobo, logger)
-        rRem <- userReminder.run(Instant.now, dryRun)
-        _ <- logger.info("Goodbye")
-      } yield rRem.asJson
-    }
-
-  def readArgs(is: InputStream): ValidatedNel[String, Boolean] = Validated.fromEither {
-    val input = Source.fromInputStream(is).mkString
-    decode[Boolean](input).leftMap(_.toString)
-  }.toValidatedNel
+  override def go(settings: Settings, dryRun: Boolean) = 
+    for {
+      logger <- LoggingInterpreter.apply
+      _ <- logger.info("Hello")
+      _ <- logger.info("Opening up a connection to Bonobo...")
+      bonobo <- BonoboInterpreter(settings, logger)
+      _ <- logger.info("Opening up a connection to SES...")
+      email <- EmailInterpreter(settings, logger)
+      _ <- logger.info("We're all set, starting...")
+      userReminder = new UserReminder(settings, email, bonobo, logger)
+      rRem <- userReminder.run(Instant.now, dryRun)
+      _ <- logger.info("Goodbye")
+    } yield rRem.asJson
 }

--- a/src/main/scala/com.gu.gibbons/lambdas/UserReminderLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/UserReminderLambda.scala
@@ -15,12 +15,8 @@ class UserReminderLambda extends GenericLambda {
   override def go(resources: Resources, logger: LoggingInterpreter, settings: Settings, dryRun: Boolean) = {
     val bonobo = new BonoboInterpreter(settings, logger, resources.dynamo, resources.http, resources.url)
     val email = new EmailInterpreter(settings, logger, resources.email, resources.url)
+    val userReminder = new UserReminder(settings, email, bonobo, logger)
 
-    for {
-      _ <- logger.info("Hello")
-      userReminder = new UserReminder(settings, email, bonobo, logger)
-      rRem <- userReminder.run(Instant.now, dryRun)
-      _ <- logger.info("Goodbye")
-    } yield rRem.asJson
+    userReminder.run(Instant.now, dryRun).map(_.asJson)
   }
 }

--- a/src/main/scala/com.gu.gibbons/lambdas/UserReminderLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/UserReminderLambda.scala
@@ -1,22 +1,6 @@
 package com.gu.gibbons
 package lambdas
 
-import io.circe.syntax._
-import java.time.Instant
 import monix.execution.Scheduler.Implicits.global
 
-import config._
-import model.{JsonFormats, Result}
-import services.interpreters._
-
-class UserReminderLambda extends GenericLambda {
-  import JsonFormats._
-
-  override def go(resources: Resources, logger: LoggingInterpreter, settings: Settings, dryRun: Boolean) = {
-    val bonobo = new BonoboInterpreter(settings, logger, resources.dynamo, resources.http, resources.url)
-    val email = new EmailInterpreter(settings, logger, resources.email, resources.url)
-    val userReminder = new UserReminder(settings, email, bonobo, logger)
-
-    userReminder.run(Instant.now, dryRun).map(_.asJson)
-  }
-}
+class UserReminderLambda extends GenericLambda(new UserReminder(_, _, _, _))

--- a/src/main/scala/com.gu.gibbons/lambdas/UserReminderLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/UserReminderLambda.scala
@@ -13,8 +13,8 @@ class UserReminderLambda extends GenericLambda {
   import JsonFormats._
 
   override def go(resources: Resources, logger: LoggingInterpreter, settings: Settings, dryRun: Boolean) = {
-    val bonobo = new BonoboInterpreter(settings, logger, resources.dynamo, resources.http)
-    val email = new EmailInterpreter(settings, logger, resources.email)
+    val bonobo = new BonoboInterpreter(settings, logger, resources.dynamo, resources.http, resources.url)
+    val email = new EmailInterpreter(settings, logger, resources.email, resources.url)
 
     for {
       _ <- logger.info("Hello")

--- a/src/main/scala/com.gu.gibbons/lambdas/UserReminderLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/UserReminderLambda.scala
@@ -12,17 +12,15 @@ import services.interpreters._
 class UserReminderLambda extends GenericLambda {
   import JsonFormats._
 
-  override def go(settings: Settings, dryRun: Boolean) = 
+  override def go(resources: Resources, logger: LoggingInterpreter, settings: Settings, dryRun: Boolean) = {
+    val bonobo = new BonoboInterpreter(settings, logger, resources.dynamo, resources.http)
+    val email = new EmailInterpreter(settings, logger, resources.email)
+
     for {
-      logger <- LoggingInterpreter.apply
       _ <- logger.info("Hello")
-      _ <- logger.info("Opening up a connection to Bonobo...")
-      bonobo <- BonoboInterpreter(settings, logger)
-      _ <- logger.info("Opening up a connection to SES...")
-      email <- EmailInterpreter(settings, logger)
-      _ <- logger.info("We're all set, starting...")
       userReminder = new UserReminder(settings, email, bonobo, logger)
       rRem <- userReminder.run(Instant.now, dryRun)
       _ <- logger.info("Goodbye")
     } yield rRem.asJson
+  }
 }

--- a/src/main/scala/com.gu.gibbons/services/BonoboService.scala
+++ b/src/main/scala/com.gu.gibbons/services/BonoboService.scala
@@ -32,7 +32,7 @@ trait BonoboService[F[_]] {
       *
       * @param user The user
       */
-    def setRemindedOn(user: User, when: Instant): F[Unit]
+    def setRemindedOn(user: User, when: Instant): F[User]
 
     /** Deletes a user and all their keys
       *

--- a/src/main/scala/com.gu.gibbons/services/BonoboService.scala
+++ b/src/main/scala/com.gu.gibbons/services/BonoboService.scala
@@ -3,27 +3,25 @@ package services
 
 // ------------------------------------------------------------------------
 import java.time.Instant
-import java.time.temporal.TemporalAmount
 import model._
 // ------------------------------------------------------------------------
 
 /** The algebra for interacting with the Bonobo database */
 trait BonoboService[F[_]] {
     /** Get all the users which have been created, or which
-      * have been extended, `period` ago
+      * have been extended, before `jadis`
       *
-      * @param period The amount of time during above which a user is
+      * @param jadis  The time before which a user is
       *               potentially expired
       */
-    def getUsers(period: TemporalAmount): F[Vector[User]]
+    def getUsers(jadis: Instant): F[Vector[User]]
 
     /** Get all the users that are potentially expired but have not
       * either confirmed or infirmed during the grace period
       *
-      * @param period The amount of time above which a user can
-      *               be deleted
+      * @param jadis The time before which a user can  be deleted
       */
-    def getInactiveUsers(period: TemporalAmount): F[Vector[User]]
+    def getInactiveUsers(jadis: Instant): F[Vector[User]]
 
     /** Start the clock for a 14 days grace period. Users
       * have 14 days to take appropriate action for their

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -7,10 +7,9 @@ import cats.syntax.show._
 import cats.instances.list._
 import java.time.{Instant, OffsetDateTime}
 import java.time.temporal.TemporalAmount
-import java.util.concurrent.TimeUnit
 import monix.eval.Task
-import okhttp3._
-import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBAsyncClientBuilder, AmazonDynamoDBAsync}
+import okhttp3.{OkHttpClient, Request}
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.gu.scanamo._
 import com.gu.scanamo.ops.ScanamoOps
 import com.gu.scanamo.query.ConditionExpression

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -18,8 +18,9 @@ import com.gu.scanamo.syntax._
 import com.gu.gibbons.config._
 import com.gu.gibbons.model._
 import com.gu.gibbons.services._
+import com.gu.gibbons.utils._
 
-class BonoboInterpreter(config: Settings, logger: LoggingService[Task], dynamoClient: AmazonDynamoDBAsync, httpClient: OkHttpClient) extends BonoboService[Task] {
+class BonoboInterpreter(config: Settings, logger: LoggingService[Task], dynamoClient: AmazonDynamoDBAsync, httpClient: OkHttpClient, urlGenerator: UrlGenerator) extends BonoboService[Task] {
 
   def getUsers(period: TemporalAmount) = for {
     jadis <- timeAgo(period)
@@ -49,8 +50,6 @@ class BonoboInterpreter(config: Settings, logger: LoggingService[Task], dynamoCl
       case _ => throw new Throwable(s"Call to Bonobo failed with ${response.message}: ${response.body}")
     }
   }
-
-  private val urlGenerator = new UrlGenerator(config)
 
   private val usersTable = Table[User](config.usersTableName)
 

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -25,7 +25,7 @@ class BonoboInterpreter(config: Settings, logger: LoggingService[Task], dynamoCl
     val jadis = OffsetDateTime.now().minus(period).toInstant.toEpochMilli
     for {
       _ <- logger.info(s"Getting all the users created before $jadis")
-      users <- getUsersMatching(period, ('extendedAt <= jadis or (not(attributeExists('extendedAt)) and 'createdAt <= jadis)))
+      users <- getUsersMatching(period, (not(attributeExists('remindedAt)) and ('extendedAt <= jadis or (not(attributeExists('extendedAt)) and 'createdAt <= jadis))))
       _ <- users.collect { case Left(err) => err }.traverse(e => logger.warn(e.show))
     } yield users.collect { case Right(user) => user }.toVector
   }

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -2,8 +2,9 @@ package com.gu.gibbons.services.interpreters
 
 import java.time.{Instant, OffsetDateTime}
 import java.time.temporal.TemporalAmount
+import java.util.concurrent.TimeUnit
 import monix.eval.Task
-import okhttp3.{OkHttpClient, Request}
+import okhttp3._
 import com.amazonaws.services.dynamodbv2.{AmazonDynamoDBAsyncClientBuilder, AmazonDynamoDBAsync}
 import com.gu.scanamo._
 import com.gu.scanamo.ops.ScanamoOps
@@ -74,7 +75,11 @@ object BonoboInterpreter {
       .withRegion(config.region)
       .build()
 
-    val httpClient = new OkHttpClient()
+    val httpClient = new OkHttpClient.Builder()
+      .connectTimeout(1, TimeUnit.SECONDS)
+      .readTimeout(1, TimeUnit.SECONDS)
+      .connectionPool(new ConnectionPool(5, 10, TimeUnit.SECONDS))
+      .build
 
     new BonoboInterpreter(config, logger, dynamoClient, httpClient)
   }

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -46,8 +46,11 @@ class BonoboInterpreter(config: Settings, logger: LoggingService[Task], dynamoCl
     val request = new Request.Builder()
       .url(urlGenerator.delete(user))
       .build
-    httpClient.newCall(request).execute()
-    ()
+    val response = httpClient.newCall(request).execute()
+    response.code match {
+      case 200 => ()
+      case _ => throw new Throwable(s"Call to Bonobo failed with ${response.message}: ${response.body}")
+    }
   }
 
   private val urlGenerator = new UrlGenerator(config)

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -39,7 +39,7 @@ class BonoboInterpreter(config: Settings, logger: LoggingService[Task], dynamoCl
   }
 
   def setRemindedOn(user: User, when: Instant) = run {
-    usersTable.update('bonoboId -> user.id.id, set('remindedAt -> when.toEpochMilli)).map(_ => ())
+    usersTable.update('id -> user.id.id, set('remindedAt -> when.toEpochMilli)).map(_ => ())
   }.map { _ => user.copy(remindedAt = Some(when)) }
 
   def deleteUser(user: User) = Task {

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -40,7 +40,7 @@ class BonoboInterpreter(config: Settings, logger: LoggingService[Task], dynamoCl
 
   def setRemindedOn(user: User, when: Instant) = run {
     usersTable.update('bonoboId -> user.id.id, set('remindedAt -> when.toEpochMilli)).map(_ => ())
-  }
+  }.map { _ => user.copy(remindedAt = Some(when)) }
 
   def deleteUser(user: User) = Task {
     val request = new Request.Builder()

--- a/src/main/scala/com.gu.gibbons/services/interpreters/EmailInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/EmailInterpreter.scala
@@ -1,5 +1,6 @@
 package com.gu.gibbons.services.interpreters
 
+import cats.syntax.flatMap._
 import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.services.simpleemail.model.{ Destination => SESDestination, Message => SESMessage, _ }
 import com.amazonaws.services.simpleemail.{AmazonSimpleEmailServiceAsyncClientBuilder, AmazonSimpleEmailServiceAsync}
@@ -52,5 +53,9 @@ object EmailInterpreter {
       .withRegion(settings.region)
       .build()
     new EmailInterpreter(settings, logger, emailClient)
+  }.attempt.flatMap {
+    case Left(error) => 
+      logger.error(s"Failed to initialize Email service: $error") >>= (_ => Task.raiseError(error))
+    case Right(bonobo) => Task.now(bonobo)
   }
 }

--- a/src/main/scala/com.gu.gibbons/services/interpreters/EmailInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/EmailInterpreter.scala
@@ -13,8 +13,9 @@ import scala.util.{Success, Failure}
 import com.gu.gibbons.config._
 import com.gu.gibbons.model._
 import com.gu.gibbons.services._
+import com.gu.gibbons.utils._
 
-final class EmailInterpreter(settings: Settings, logger: LoggingService[Task], emailClient: AmazonSimpleEmailServiceAsync) extends EmailService[Task] {
+final class EmailInterpreter(settings: Settings, logger: LoggingService[Task], emailClient: AmazonSimpleEmailServiceAsync, urlGenerator: UrlGenerator) extends EmailService[Task] {
   def sendReminder(user: User) = 
     sendEmail(user, Settings.reminderSubject, reminderEmail(user))
   def sendDeleted(user: User) = 
@@ -41,8 +42,6 @@ final class EmailInterpreter(settings: Settings, logger: LoggingService[Task], e
     Cancelable.empty
   }
 
-  private val gen = new UrlGenerator(settings)
-
-  private def reminderEmail(user: User) = html.reminder(user, gen).toString
+  private def reminderEmail(user: User) = html.reminder(user, urlGenerator).toString
   private def deletedEmail(user: User) = html.deleted(user).toString
 }

--- a/src/main/scala/com.gu.gibbons/services/interpreters/EmailInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/EmailInterpreter.scala
@@ -46,16 +46,3 @@ final class EmailInterpreter(settings: Settings, logger: LoggingService[Task], e
   private def reminderEmail(user: User) = html.reminder(user, gen).toString
   private def deletedEmail(user: User) = html.deleted(user).toString
 }
-
-object EmailInterpreter {
-  def apply(settings: Settings, logger: LoggingService[Task]): Task[EmailInterpreter] = Task.evalOnce {
-    val emailClient = AmazonSimpleEmailServiceAsyncClientBuilder.standard()
-      .withRegion(settings.region)
-      .build()
-    new EmailInterpreter(settings, logger, emailClient)
-  }.attempt.flatMap {
-    case Left(error) => 
-      logger.error(s"Failed to initialize Email service: $error") >>= (_ => Task.raiseError(error))
-    case Right(bonobo) => Task.now(bonobo)
-  }
-}

--- a/src/main/scala/com.gu.gibbons/services/interpreters/LoggingInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/LoggingInterpreter.scala
@@ -20,8 +20,8 @@ class LoggingInterpreter(logger: Logger) extends LoggingService[Task] {
 }
 
 object LoggingInterpreter {
-    def apply(): Task[LoggingInterpreter] = Task.evalOnce {
-        val logger = LogManager.getLogger(classOf[LoggingInterpreter])
+    def apply(owner: String): Task[LoggingInterpreter] = Task.evalOnce {
+        val logger = LogManager.getLogger(owner)
         new LoggingInterpreter(logger)
     }
 }

--- a/src/main/scala/com.gu.gibbons/utils/UrlGenerator.scala
+++ b/src/main/scala/com.gu.gibbons/utils/UrlGenerator.scala
@@ -1,15 +1,13 @@
-package com.gu.gibbons
-package model
+package com.gu.gibbons.utils
 
+import com.gu.gibbons.config.Settings
+import com.gu.gibbons.model.User
 import java.time.Instant
 import java.security.{ MessageDigest, Security }
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 
-import config._
 
-class HashGenerator {
-  import HashGenerator._
-
+abstract class HashGenerator(md: MessageDigest) {
   def params(user: User, salt: String): String = {
     s"h=${hash(user.id.id, user.remindedAt.get, salt)}"
   }
@@ -20,16 +18,19 @@ class HashGenerator {
   }
 }
 
-object HashGenerator {
-  Security.addProvider(new BouncyCastleProvider())
-  private val md = MessageDigest.getInstance("SHA3-512")
-}
-
-class UrlGenerator(settings: Settings) extends HashGenerator {
+class UrlGenerator(settings: Settings, md: MessageDigest) extends HashGenerator(md) {
   private def url(action: String, user: User) =
     s"${settings.bonoboUrl}/user/${user.id.id}/${action}?${params(user, settings.salt)}"
 
   def extend(user: User): String = url("extend", user)
 
   def delete(user: User): String = url("delete", user)
+}
+
+object UrlGenerator {
+  def apply(settings: Settings) = {
+    Security.addProvider(new BouncyCastleProvider())
+    val md = MessageDigest.getInstance("SHA3-512")
+    new UrlGenerator(settings, md)
+  }
 }

--- a/src/main/twirl/reminder.scala.html
+++ b/src/main/twirl/reminder.scala.html
@@ -1,4 +1,5 @@
-@import com.gu.gibbons.model.{User, UrlGenerator}
+@import com.gu.gibbons.model.User
+@import com.gu.gibbons.utils.UrlGenerator
 @(to: User, gen: UrlGenerator)
 
 @shell("Your API keys are about to expire") {

--- a/src/test/scala/com.gu.bonobo/UserReminderSpec.scala
+++ b/src/test/scala/com.gu.bonobo/UserReminderSpec.scala
@@ -18,7 +18,8 @@ class IntegrationTests extends FlatSpec with Matchers with Inspectors {
         "",
         "",
         "",
-        Email("")
+        Email(""),
+        HttpSettings(0, 0, 0, 0)
     )
 
     val userReminder = new UserReminder(settings, emailService, bonoboService, loggingService)

--- a/src/test/scala/com.gu.bonobo/UserReminderSpec.scala
+++ b/src/test/scala/com.gu.bonobo/UserReminderSpec.scala
@@ -26,7 +26,7 @@ class IntegrationTests extends FlatSpec with Matchers with Inspectors {
     val userDidNotAnswer = new UserDidNotAnswer(settings, emailService, bonoboService, loggingService)
 
     "The Reminder service" should "send reminders, duh" in {
-        val ((newUsers, emailService), sentEmails) = userReminder.run(false).run((users, Set.empty)).value
+        val ((newUsers, emailService), sentEmails) = userReminder.run(today, false).run((users, Set.empty)).value
         val remindedUsers = newUsers.filter(_._2.remindedAt.exists(_ == todayInstant)).map(_._2.id).toSet
         forAll(remindedUsers) { u => 
             emailService should contain (users(u).email)  
@@ -35,7 +35,7 @@ class IntegrationTests extends FlatSpec with Matchers with Inspectors {
     }
 
     "The DidNotAnswer service" should "remove expired keys" in {
-        val ((newUsers, emailService), _) = userDidNotAnswer.run(false).run((users, Set.empty)).value
+        val ((newUsers, emailService), _) = userDidNotAnswer.run(today, false).run((users, Set.empty)).value
         val deletedKeys = newUsers.filter(_._2.remindedAt.exists(t => today.minus(Settings.gracePeriod).toInstant.compareTo(t) >= 0))
         
         deletedKeys.size shouldBe 0

--- a/src/test/scala/com.gu.bonobo/UserReminderSpec.scala
+++ b/src/test/scala/com.gu.bonobo/UserReminderSpec.scala
@@ -26,7 +26,7 @@ class IntegrationTests extends FlatSpec with Matchers with Inspectors {
     val userDidNotAnswer = new UserDidNotAnswer(settings, emailService, bonoboService, loggingService)
 
     "The Reminder service" should "send reminders, duh" in {
-        val ((newUsers, emailService), sentEmails) = userReminder.run(todayInstant, false).run((users, Set.empty)).value
+        val ((newUsers, emailService), sentEmails) = userReminder.run(false).run((users, Set.empty)).value
         val remindedUsers = newUsers.filter(_._2.remindedAt.exists(_ == todayInstant)).map(_._2.id).toSet
         forAll(remindedUsers) { u => 
             emailService should contain (users(u).email)  

--- a/src/test/scala/com.gu.bonobo/services/interpreters.scala
+++ b/src/test/scala/com.gu.bonobo/services/interpreters.scala
@@ -22,9 +22,9 @@ class BonoboServiceInterpreter extends BonoboService[TestProgram] {
     (s, res)
   }
 
-  def setRemindedOn(user: User, when: Instant) = State[Repo, Unit] { case s@(users, es) =>
+  def setRemindedOn(user: User, when: Instant) = State[Repo, User] { case s@(users, es) =>
     val newUser = users(user.id).copy(remindedAt = Some(when))
-    ((users.updated(user.id, newUser), es), ())
+    ((users.updated(user.id, newUser), es), newUser)
   }
 
   def deleteUser(user: User) = State[Repo, Unit] { case (users, es) =>

--- a/src/test/scala/com.gu.bonobo/services/interpreters.scala
+++ b/src/test/scala/com.gu.bonobo/services/interpreters.scala
@@ -4,20 +4,19 @@ package services
 import cats.Monad
 import cats.data.State
 import java.time.Instant
-import java.time.temporal.TemporalAmount
 import model._
 
 class BonoboServiceInterpreter extends BonoboService[TestProgram] {
-  def getUsers(period: TemporalAmount) = State[Repo, Vector[User]] { case s@(users, _) =>
+  def getUsers(jadis: Instant) = State[Repo, Vector[User]] { case s@(users, _) =>
     val res = users.filter { 
-      case (_, user) => fixtures.today.minus(period).toInstant.compareTo(user.extendedAt.getOrElse(user.createdAt)) >= 0
+      case (_, user) => user.extendedAt.getOrElse(user.createdAt).compareTo(jadis) <= 0
     }.values.toVector
     (s, res)
   }
 
-  def getInactiveUsers(period: TemporalAmount) = State[Repo, Vector[User]] { case s@(users, _) =>
+  def getInactiveUsers(jadis: Instant) = State[Repo, Vector[User]] { case s@(users, _) =>
     val res = users.filter { 
-      case (_, user) => user.remindedAt.exists(r => fixtures.today.minus(period).toInstant.compareTo(r) >= 0)
+      case (_, user) => user.remindedAt.exists(r => r.compareTo(jadis) <= 0)
     }.values.toVector
     (s, res)
   }


### PR DESCRIPTION
Another round of improvements to the lambdas:

- resource allocation is pushed to the edge of the program; previously this responsibility was disseminated into each interpreter.
- added resource cleanup to be a good citizen. It is unlikely this changes anything, except if the lambda is recycled.
- the previous two changes allow the program to run only if _all_ resources are available and the latter get properly cleaned up no matter what the outcome of the program is. Monix provides a nice API to do that: `Task[A].bracket(computation)(cleanup)`
- the script of both lambdas is entirely generic, so it is abstracted in a common interface
- some smaller improvements such as:
  - getting the current time is an effect, now captured as such
  - dynamo read errors are swallowed, they are now properly logged (but still swallowed)
  - there's now a singleton object for hashing urls shared across all interpreters

It's probably a good idea to look at each commit separately.