### PR TITLE
Notify only users who own Developer keys

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -35,6 +35,7 @@ Globals:
                 SALT: !Ref Salt
                 BONOBO_URL: !Ref BonoboUrl
                 BONOBO_USERS_TABLE: !Sub bonobo-${Stage}-users
+                BONOBO_KEYS_TABLE: !Sub bonobo-${Stage}-keys
         CodeUri:
             Bucket: content-api-dist
             Key: !Sub ${Stack}/${Stage}/${App}-reminder/${App}.jar

--- a/src/main/scala/com.gu.gibbons/UserReminder.scala
+++ b/src/main/scala/com.gu.gibbons/UserReminder.scala
@@ -35,7 +35,7 @@ class UserReminder[F[_] : Monad](settings: Settings, email: EmailService[F], bon
         _ <- logger.info(s"Getting all developer keys")
         keys <- bonobo.getDevelopers
         _ <- logger.info(s"Getting all the users older than ${Settings.inactivityPeriod}")
-        users <- keys.foldMapM(bonobo.getUser(_, thenL).map(_.toVector))
+        users <- bonobo.getUsers(keys, thenL)
         _ <- logger.info(s"Found ${users.size} users.")
         ress <- if (dryRun) Monad[F].pure(Map.empty[UserId, EmailResult]) else users.traverse { user => 
           for {

--- a/src/main/scala/com.gu.gibbons/UserReminder.scala
+++ b/src/main/scala/com.gu.gibbons/UserReminder.scala
@@ -34,9 +34,9 @@ class UserReminder[F[_] : Monad](settings: Settings, email: EmailService[F], bon
       for {
         _ <- logger.info(s"Getting all the users older than ${Settings.inactivityPeriod}")
         users <- bonobo.getUsers(Settings.inactivityPeriod)
-        _ <- logger.info(s"... but we only need developer accounts")
+        _ <- logger.info(s"Got s{users.length}... but we only need developer accounts")
         devs <- users.foldMapM(u => bonobo.isDeveloper(u).map(b => if (b) Vector(u) else Vector.empty))
-        _ <- logger.info(s"Found ${devs.length} users.")
+        _ <- logger.info(s"Found ${devs.length} developers.")
         ress <- if (dryRun) Monad[F].pure(Map.empty[UserId, EmailResult]) else devs.traverse { user => 
           for {
             newUser <- bonobo.setRemindedOn(user, nowL)

--- a/src/main/scala/com.gu.gibbons/UserReminder.scala
+++ b/src/main/scala/com.gu.gibbons/UserReminder.scala
@@ -3,7 +3,7 @@ package com.gu.gibbons
 // ------------------------------------------------------------------------
 import cats.Monad
 import config.Settings
-import java.time.Instant
+import java.time.{OffsetDateTime, ZoneOffset}
 import model._
 import services._
 // ------------------------------------------------------------------------
@@ -27,24 +27,27 @@ class UserReminder[F[_] : Monad](settings: Settings, email: EmailService[F], bon
       * 3- Sends a reminder email to each user 
       * 4- Update keys to log when a reminder has been sent
       */
-    def run(now: Instant, dryRun: Boolean): F[Result] = 
-      if (dryRun) 
-        for {
-          _ <- logger.info("Yop, who's up for receiving a reminder?")
-          users <- bonobo.getUsers(Settings.inactivityPeriod)
-        } yield DryRun(users)
-      else
-        for {
-          _ <- logger.info(s"Getting all the users older than ${Settings.inactivityPeriod}")
-          users <- bonobo.getUsers(Settings.inactivityPeriod)
-          _ <- logger.info(s"Found ${users.length} users. Let's send some emails...")
-          ress <- users.filterNot(u => Settings.whitelist(u.id.id)).traverse { user => 
-            for {
-              newUser <- bonobo.setRemindedOn(user, now)
-              res <- email.sendReminder(newUser)
-            } yield (newUser.id -> res)
-          }.map(_.toMap)
-          _ <- logger.info("aaaand that's a wrap! See you next time.")
-        } yield FullRun(ress)
+    def run(now: OffsetDateTime, dryRun: Boolean): F[Map[UserId, EmailResult]] = {
+      val nowL = now.toInstant.toEpochMilli
+      val thenL = now.minus(Settings.inactivityPeriod).toInstant.toEpochMilli
+      for {
+        _ <- logger.info(s"Getting all developer keys")
+        keys <- bonobo.getDevelopers
+        _ <- logger.info(s"Getting all the users older than ${Settings.inactivityPeriod}")
+        users <- keys.traverse(bonobo.getUser(_)).map(_.filter(_.exists(oldEnough(thenL))).map(_.get))
+        _ <- logger.info(s"Found ${users.size} users.")
+        ress <- if (dryRun) Monad[F].pure(Map.empty[UserId, EmailResult]) else users.traverse { user => 
+          for {
+            newUser <- bonobo.setRemindedOn(user, nowL)
+            res <- email.sendReminder(newUser)
+          } yield (newUser.id -> res)
+        }.map(_.toMap)
+        _ <- logger.info("aaaand that's a wrap! See you next time.")
+      } yield ress
+    }
+
+    private def oldEnough(jadis: Long)(user: User): Boolean =
+      !user.remindedAt.isDefined && (user.extendedAt.exists(_ <= jadis) || !user.extendedAt.isDefined && user.createdAt <= jadis)
+
 }
 

--- a/src/main/scala/com.gu.gibbons/UserReminder.scala
+++ b/src/main/scala/com.gu.gibbons/UserReminder.scala
@@ -34,7 +34,7 @@ class UserReminder[F[_] : Monad](settings: Settings, email: EmailService[F], bon
       for {
         _ <- logger.info(s"Getting all the users older than ${Settings.inactivityPeriod}")
         users <- bonobo.getUsers(Settings.inactivityPeriod)
-        _ <- logger.info(s"Got s{users.length}... but we only need developer accounts")
+        _ <- logger.info(s"Got ${users.length}... but we only need developer accounts")
         devs <- users.foldMapM(u => bonobo.isDeveloper(u).map(b => if (b) Vector(u) else Vector.empty))
         _ <- logger.info(s"Found ${devs.length} developers.")
         ress <- if (dryRun) Monad[F].pure(Map.empty[UserId, EmailResult]) else devs.traverse { user => 

--- a/src/main/scala/com.gu.gibbons/config/Settings.scala
+++ b/src/main/scala/com.gu.gibbons/config/Settings.scala
@@ -14,6 +14,7 @@ import model.Email
 case class Settings(
   region: Regions,
   usersTableName: String,
+  keysTableName: String,
   salt: String,
   bonoboUrl: String,
   fromAddress: Email
@@ -25,26 +26,17 @@ object Settings {
   val reminderSubject = "Your Content API keys are about to expire"
   val deletedSubject = "Your Content API keys have been deleted"
 
-  /** These accounts belong to the Guardian digital department and can
-    *  safely be ignored
-    */
-  val whitelist = Set(
-    "e3e345ef-b366-4641-c634-1228b1b9ff9a",
-    "7d8f16ba-b57b-491e-91cf-d9a9d1431ccf",
-    "10f1ba90-838e-4bc2-aa56-c084011012e6",
-    "ea39a2bb-630d-4565-97ef-a47eff4ec300"
-  )
-
   def fromEnvironment: ValidatedNel[String, Settings] =
     parseEnv(System.getenv.asScala.toMap)
     
   def parseEnv(env: Map[String, String]) =
     ( getEnv(env, "AWS_REGION").andThen(makeRegion)
     , getEnv(env, "BONOBO_USERS_TABLE")
+    , getEnv(env, "BONOBO_KEYS_TABLE")
     , getEnv(env, "SALT")
     , getEnv(env, "BONOBO_URL")
     , getEnv(env, "EMAIL_ORIGIN").map(Email(_))
-    ).mapN(Settings(_, _, _, _, _))
+    ).mapN(Settings(_, _, _, _, _, _))
 
   private def makeRegion(r: String): ValidatedNel[String, Regions] = Validated.fromTry {
     Try(Regions.fromName(r))

--- a/src/main/scala/com.gu.gibbons/lambdas/UserReminderLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/UserReminderLambda.scala
@@ -3,11 +3,11 @@ package lambdas
 
 import cats.data.{ Validated, ValidatedNel }
 import com.amazonaws.services.lambda.runtime.Context; 
-import java.time.Instant
 import io.circe.parser.decode
 import io.circe.syntax._
 import io.circe.Json
 import java.io.{InputStream, OutputStream}
+import java.time.{OffsetDateTime, ZoneOffset}
 import monix.execution.Scheduler.Implicits.global
 import monix.eval.Task
 import scala.concurrent.Await
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
 import scala.io.Source
 
 import config._
-import model.{JsonFormats, Result}
+import model.JsonFormats
 import services.interpreters._
 
 class UserReminderLambda {
@@ -44,7 +44,7 @@ class UserReminderLambda {
         email <- EmailInterpreter(settings, logger)
         _ <- logger.info("We're all set, starting...")
         userReminder = new UserReminder(settings, email, bonobo, logger)
-        rRem <- userReminder.run(Instant.now, dryRun)
+        rRem <- userReminder.run(OffsetDateTime.now(ZoneOffset.UTC), dryRun)
         _ <- logger.info("Goodbye")
       } yield rRem.asJson
     }

--- a/src/main/scala/com.gu.gibbons/model/Json.scala
+++ b/src/main/scala/com.gu.gibbons/model/Json.scala
@@ -1,7 +1,7 @@
 package com.gu.gibbons
 package model
 
-import io.circe.{Encoder, Json}
+import io.circe.{Encoder, Json, JsonObject}
 import io.circe.generic.semiauto.deriveEncoder
 import io.circe.syntax._
 import java.time.{Instant, OffsetDateTime, ZoneOffset}
@@ -17,16 +17,9 @@ object JsonFormats {
     implicit val email: Encoder[Email] = deriveEncoder
     implicit val emailResult: Encoder[EmailResult] = deriveEncoder
     implicit val user: Encoder[User] = deriveEncoder
-    
-    implicit val encoder: Encoder[Result] = new Encoder[Result] {
-        final def apply(res: Result) = res match {
-            case DryRun(users) => users.asJson
-            case FullRun(result) => 
-                val objs = result.map { case (userId, emailRes) => Json.obj(
-                    "user" -> Json.fromString(userId.id),
-                    "email" -> emailRes.asJson
-                )}.toSeq
-                Json.arr(objs:_*)
-        }
+
+    implicit val map: Encoder[Map[UserId, EmailResult]] = new Encoder[Map[UserId, EmailResult]] {
+        final def apply(m: Map[UserId, EmailResult]) =
+            Json.fromJsonObject(JsonObject(m.map(u => u._1.id -> u._2.asJson).toSeq: _*))
     }
 }

--- a/src/main/scala/com.gu.gibbons/model/Json.scala
+++ b/src/main/scala/com.gu.gibbons/model/Json.scala
@@ -20,6 +20,6 @@ object JsonFormats {
 
     implicit val map: Encoder[Map[UserId, EmailResult]] = new Encoder[Map[UserId, EmailResult]] {
         final def apply(m: Map[UserId, EmailResult]) =
-            Json.fromJsonObject(JsonObject(m.map(u => u._1.id -> u._2.asJson).toSeq: _*))
+            Json.fromJsonObject(JsonObject(m.map { case (UserId(id), result) => id -> result.asJson }.toSeq: _*))
     }
 }

--- a/src/main/scala/com.gu.gibbons/model/Result.scala
+++ b/src/main/scala/com.gu.gibbons/model/Result.scala
@@ -1,9 +1,0 @@
-package com.gu.gibbons
-package model
-
-import io.circe.Encoder
-import io.circe.generic.semiauto._
-
-sealed trait Result
-case class DryRun(users: Vector[User]) extends Result
-case class FullRun(result: Map[UserId, EmailResult]) extends Result

--- a/src/main/scala/com.gu.gibbons/model/UrlGenerator.scala
+++ b/src/main/scala/com.gu.gibbons/model/UrlGenerator.scala
@@ -14,8 +14,8 @@ class HashGenerator {
     s"h=${hash(user.id.id, user.remindedAt.get, salt)}"
   }
 
-  def hash(id: String, when: Instant, salt: String): String = {
-    val hash = id + when.toEpochMilli.toString + salt
+  def hash(id: String, when: Long, salt: String): String = {
+    val hash = id + when.toString + salt
     md.digest(hash.getBytes).map("%02X".format(_)).mkString
   }
 }

--- a/src/main/scala/com.gu.gibbons/services/BonoboService.scala
+++ b/src/main/scala/com.gu.gibbons/services/BonoboService.scala
@@ -9,13 +9,11 @@ import model._
 
 /** The algebra for interacting with the Bonobo database */
 trait BonoboService[F[_]] {
-    /** Get all the users which have been created, or which
-      * have been extended, `period` ago
-      *
-      * @param period The amount of time during above which a user is
-      *               potentially expired
-      */
-    def getUsers(period: TemporalAmount): F[Vector[User]]
+    /** Gets all the user Ids owning at least one developer key */
+    def getDevelopers: F[Vector[Key]]
+
+    /** Gets a user by their id */
+    def getUser(key: Key): F[Option[User]]
 
     /** Get all the users that are potentially expired but have not
       * either confirmed or infirmed during the grace period
@@ -32,7 +30,7 @@ trait BonoboService[F[_]] {
       *
       * @param user The user
       */
-    def setRemindedOn(user: User, when: Instant): F[User]
+    def setRemindedOn(user: User, when: Long): F[User]
 
     /** Deletes a user and all their keys
       *

--- a/src/main/scala/com.gu.gibbons/services/BonoboService.scala
+++ b/src/main/scala/com.gu.gibbons/services/BonoboService.scala
@@ -37,4 +37,9 @@ trait BonoboService[F[_]] {
       * @param user The user
       */
     def deleteUser(user: User): F[Unit]
+
+    def oldEnough(user: User, jadis: Long) =
+      !user.remindedAt.isDefined && (
+        user.extendedAt.exists(_ <= jadis) || !user.extendedAt.isDefined && user.createdAt <= jadis
+      )
 }

--- a/src/main/scala/com.gu.gibbons/services/BonoboService.scala
+++ b/src/main/scala/com.gu.gibbons/services/BonoboService.scala
@@ -13,7 +13,7 @@ trait BonoboService[F[_]] {
     def getDevelopers: F[Vector[Key]]
 
     /** Gets a user by their id */
-    def getUser(key: Key): F[Option[User]]
+    def getUser(key: Key, jadis: Long): F[Option[User]]
 
     /** Get all the users that are potentially expired but have not
       * either confirmed or infirmed during the grace period

--- a/src/main/scala/com.gu.gibbons/services/BonoboService.scala
+++ b/src/main/scala/com.gu.gibbons/services/BonoboService.scala
@@ -10,10 +10,10 @@ import model._
 /** The algebra for interacting with the Bonobo database */
 trait BonoboService[F[_]] {
     /** Gets all the user Ids owning at least one developer key */
-    def getDevelopers: F[Vector[Key]]
+    def getDevelopers: F[Set[Key]]
 
     /** Gets a user by their id */
-    def getUser(key: Key, jadis: Long): F[Option[User]]
+    def getUsers(keys: Set[Key], jadis: Long): F[Vector[User]]
 
     /** Get all the users that are potentially expired but have not
       * either confirmed or infirmed during the grace period

--- a/src/main/scala/com.gu.gibbons/services/BonoboService.scala
+++ b/src/main/scala/com.gu.gibbons/services/BonoboService.scala
@@ -9,11 +9,15 @@ import model._
 
 /** The algebra for interacting with the Bonobo database */
 trait BonoboService[F[_]] {
-    /** Gets all the user Ids owning at least one developer key */
-    def getDevelopers: F[Set[Key]]
+    /** Get all the users which have been created, or which
+      * have been extended, `period` ago 
+      * 
+      * @param period The amount of time during above which a user is
+      *               potentially expired
+      */
+    def getUsers(period: TemporalAmount): F[Vector[User]]
 
-    /** Gets a user by their id */
-    def getUsers(keys: Set[Key], jadis: Long): F[Vector[User]]
+    def isDeveloper(user: User): F[Boolean]
 
     /** Get all the users that are potentially expired but have not
       * either confirmed or infirmed during the grace period

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -37,11 +37,6 @@ class BonoboInterpreter(config: Settings, logger: LoggingService[Task], dynamoCl
     _ <- users.collect { case Left(error) => error }.traverse(e => logger.warn(e.show))
   } yield users.collect { case Right(u) if oldEnough(u, jadis) => u }
 
-  private def oldEnough(user: User, jadis: Long) =
-    !user.remindedAt.isDefined && (
-      user.extendedAt.exists(_ <= jadis) || !user.extendedAt.isDefined && user.createdAt <= jadis
-    )
-
   def getInactiveUsers(period: TemporalAmount) = {
     val jadis = OffsetDateTime.now(ZoneOffset.UTC).minus(period).toInstant.toEpochMilli
     for {

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -1,6 +1,6 @@
 package com.gu.gibbons.services.interpreters
 
-import java.time.{Instant, OffsetDateTime}
+import java.time.{OffsetDateTime, ZoneOffset}
 import java.time.temporal.TemporalAmount
 import java.util.concurrent.TimeUnit
 import monix.eval.Task
@@ -22,25 +22,30 @@ class BonoboInterpreter(config: Settings, logger: LoggingService[Task], dynamoCl
   import cats.syntax.show._
   import cats.instances.list._
 
-  def getUsers(period: TemporalAmount) = {
-    val jadis = OffsetDateTime.now().minus(period).toInstant.toEpochMilli
-    for {
-      _ <- logger.info(s"Getting all the users created before $jadis")
-      users <- getUsersMatching(period, (not(attributeExists('remindedAt)) and ('extendedAt <= jadis or (not(attributeExists('extendedAt)) and 'createdAt <= jadis))))
-      _ <- users.collect { case Left(err) => err }.traverse(e => logger.warn(e.show))
-    } yield users.collect { case Right(user) => user }.toVector
-  }
+  def getDevelopers = for {
+    keys <- run {
+      keysTable.filter('tier -> "Developer").scan()
+    }
+    _ <- keys.collect { case Left(error) => error }.traverse(e => logger.warn(e.show))
+  } yield keys.collect { case Right(k) => k }.toVector.distinct
+
+  def getUser(key: Key) = for {
+    users <- run {
+      usersTable.query('id -> key.userId.id)
+    }
+    _ <- users.collect { case Left(error) => error }.traverse(e => logger.warn(e.show))
+  } yield users.collectFirst { case Right(u) => u }
 
   def getInactiveUsers(period: TemporalAmount) = {
-    val jadis = OffsetDateTime.now().minus(period).toInstant.toEpochMilli
+    val jadis = OffsetDateTime.now(ZoneOffset.UTC).minus(period).toInstant.toEpochMilli
     for {
       _ <- logger.info(s"Getting all the users created before $jadis")
       users <- getUsersMatching(period, attributeExists('remindedAt) and 'remindedAt <= jadis)
     } yield users.collect { case Right(user) => user }.toVector
   }
 
-  def setRemindedOn(user: User, when: Instant) = run {
-    usersTable.update('id -> user.id.id, set('remindedAt -> when.toEpochMilli)).map(_ => ())
+  def setRemindedOn(user: User, when: Long) = run {
+    usersTable.update('id -> user.id.id, set('remindedAt -> when)).map(_ => ())
   }.map { _ => user.copy(remindedAt = Some(when)) }
 
   def deleteUser(user: User) = Task {
@@ -57,6 +62,8 @@ class BonoboInterpreter(config: Settings, logger: LoggingService[Task], dynamoCl
   private val urlGenerator = new UrlGenerator(config)
 
   private val usersTable = Table[User](config.usersTableName)
+
+  private val keysTable = Table[Key](config.keysTableName)
 
   private def run[A](program: ScanamoOps[A]) = Task.deferFutureAction { implicit scheduler => 
     ScanamoAsync.exec(dynamoClient)(program) 

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -34,6 +34,7 @@ class BonoboInterpreter(config: Settings, logger: LoggingService[Task], dynamoCl
 
   def isDeveloper(user: User) = for {
     keys <- run { keysTable.filter('bonoboId -> user.id.id).scan() }
+    _ <- logger.info(s"Found ${keys.length} for user ${user.id.id}")
   } yield keys.exists(_.contains { key: Key => key.tier == "Developer" })
 
   def getInactiveUsers(period: TemporalAmount) = {

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -34,7 +34,7 @@ class BonoboInterpreter(config: Settings, logger: LoggingService[Task], dynamoCl
 
   def isDeveloper(user: User) = for {
     keys <- run { keysTable.filter('bonoboId -> user.id.id).scan() }
-  } yield keys.exists(_.contains("Developer"))
+  } yield keys.exists(_.exists(_.tier == "Developer"))
 
   def getInactiveUsers(period: TemporalAmount) = {
     val jadis = OffsetDateTime.now(ZoneOffset.UTC).minus(period).toInstant.toEpochMilli

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -34,8 +34,7 @@ class BonoboInterpreter(config: Settings, logger: LoggingService[Task], dynamoCl
 
   def isDeveloper(user: User) = for {
     keys <- run { keysTable.filter('bonoboId -> user.id.id).scan() }
-    _ <- logger.info(s"Found ${keys.length} for user ${user.id.id}")
-  } yield keys.exists(_.contains { key: Key => key.tier == "Developer" })
+  } yield keys.exists(_.contains("Developer"))
 
   def getInactiveUsers(period: TemporalAmount) = {
     val jadis = OffsetDateTime.now(ZoneOffset.UTC).minus(period).toInstant.toEpochMilli

--- a/src/test/scala/com.gu.bonobo/UserReminderSpec.scala
+++ b/src/test/scala/com.gu.bonobo/UserReminderSpec.scala
@@ -18,6 +18,7 @@ class IntegrationTests extends FlatSpec with Matchers with Inspectors {
         "",
         "",
         "",
+        "",
         Email("")
     )
 
@@ -25,17 +26,17 @@ class IntegrationTests extends FlatSpec with Matchers with Inspectors {
     val userDidNotAnswer = new UserDidNotAnswer(settings, emailService, bonoboService, loggingService)
 
     "The Reminder service" should "send reminders, duh" in {
-        val ((newUsers, emailService), sentEmails) = userReminder.run(todayInstant, false).run((users, Set.empty)).value
-        val remindedUsers = newUsers.filter(_._2.remindedAt.exists(_ == todayInstant)).map(_._2.id).toSet
+        val ((newUsers, emailService, _), sentEmails) = userReminder.run(today, false).run((users, Set.empty, keys)).value
+        val remindedUsers = newUsers.filter(_._2.remindedAt.exists(_ == todayInstant.toEpochMilli)).map(_._2.id).toSet
         forAll(remindedUsers) { u => 
             emailService should contain (users(u).email)  
         }
-        sentEmails shouldBe a [FullRun]
+        sentEmails should not be empty
     }
 
     "The DidNotAnswer service" should "remove expired keys" in {
-        val ((newUsers, emailService), _) = userDidNotAnswer.run(false).run((users, Set.empty)).value
-        val deletedKeys = newUsers.filter(_._2.remindedAt.exists(t => today.minus(Settings.gracePeriod).toInstant.compareTo(t) >= 0))
+        val ((newUsers, emailService, _), _) = userDidNotAnswer.run(false).run((users, Set.empty, keys)).value
+        val deletedKeys = newUsers.filter(_._2.remindedAt.exists(t => today.minus(Settings.gracePeriod).toInstant.toEpochMilli >= t))
         
         deletedKeys.size shouldBe 0
     }

--- a/src/test/scala/com.gu.bonobo/config/SettingsSpec.scala
+++ b/src/test/scala/com.gu.bonobo/config/SettingsSpec.scala
@@ -6,6 +6,7 @@ class SettingsSpec extends FlatSpec with Matchers with Inspectors {
   private val validEnv = Map(
     "AWS_REGION"         -> "eu-west-1",
     "BONOBO_USERS_TABLE" -> "How",
+    "BONOBO_KEYS_TABLE"  -> "Well",
     "SALT"               -> "Are",
     "BONOBO_URL"         -> "You",
     "EMAIL_ORIGIN"       -> "Doing"
@@ -14,6 +15,7 @@ class SettingsSpec extends FlatSpec with Matchers with Inspectors {
   private val invalidRegion = Map(
     "AWS_REGION"         -> "Hello",
     "BONOBO_USERS_TABLE" -> "How",
+    "BONOBO_KEYS_TABLE"  -> "Well",
     "SALT"               -> "Are",
     "BONOBO_URL"         -> "You",
     "EMAIL_ORIGIN"       -> "Doing"
@@ -46,7 +48,7 @@ class SettingsSpec extends FlatSpec with Matchers with Inspectors {
 
     result.isValid shouldBe false
     result.fold(
-      es => es.length shouldBe 5,
+      es => es.length shouldBe validEnv.size,
       _ => fail("Won't happen")
     )
   }

--- a/src/test/scala/com.gu.bonobo/services/interpreters.scala
+++ b/src/test/scala/com.gu.bonobo/services/interpreters.scala
@@ -10,27 +10,27 @@ import model._
 class BonoboServiceInterpreter extends BonoboService[TestProgram] {
   import cats.implicits._
 
-  def getUsers(period: TemporalAmount): TestProgram[Vector[User]] = 
-    State.get.map(_._1.filter { 
-      case (_, user) => fixtures.today.minus(period).toInstant.compareTo(user.extendedAt.getOrElse(user.createdAt)) >= 0
-    }.values.toVector)
+  def getDevelopers: TestProgram[Vector[Key]] = State.get.map(_._3)
+
+  def getUser(key: Key): TestProgram[Option[User]] =
+    State.get.map(_._1.get(key.userId))
 
   def getInactiveUsers(period: TemporalAmount): TestProgram[Vector[User]] = 
     State.get.map(_._1.filter { 
-      case (_, user) => user.remindedAt.exists(r => fixtures.today.minus(period).toInstant.compareTo(r) >= 0)
+      case (_, user) => user.remindedAt.exists(r => fixtures.today.minus(period).toInstant.toEpochMilli >= r)
     }.values.toVector)
 
-  def setRemindedOn(user: User, when: Instant): TestProgram[User] = 
-    State.get.flatMap { case (users, emails) =>
+  def setRemindedOn(user: User, when: Long): TestProgram[User] = 
+    State.get.flatMap { case (users, emails, keys) =>
       val newUser = users(user.id).copy(remindedAt = Some(when))
       for {
-        _ <- State.set((users.updated(user.id, newUser), emails))
+        _ <- State.set((users.updated(user.id, newUser), emails, keys))
       } yield newUser
     }
 
   def deleteUser(user: User): TestProgram[Unit] = for {
     s <- State.get
-    _ <- State.set((s._1 - user.id, s._2))
+    _ <- State.set((s._1 - user.id, s._2, s._3))
   } yield ()
 }
 
@@ -59,11 +59,11 @@ class EmailServiceInterpreter extends EmailService[TestProgram] {
 
   def sendReminder(user: User): TestProgram[EmailResult] = for { 
     s <- State.get
-    _ <- State.set((s._1, s._2 + user.email))
+    _ <- State.set((s._1, s._2 + user.email, s._3))
   } yield result("Reminder email", user)
   
   def sendDeleted(user: User): TestProgram[EmailResult] = for {
     s <- State.get
-    _ <- State.set((s._1, s._2 + user.email))
+    _ <- State.set((s._1, s._2 + user.email, s._3))
   } yield result("Deletion email", user)
 }

--- a/src/test/scala/com.gu.bonobo/services/interpreters.scala
+++ b/src/test/scala/com.gu.bonobo/services/interpreters.scala
@@ -10,10 +10,12 @@ import model._
 class BonoboServiceInterpreter extends BonoboService[TestProgram] {
   import cats.implicits._
 
-  def getDevelopers: TestProgram[Vector[Key]] = State.get.map(_._3)
+  def getDevelopers: TestProgram[Set[Key]] = State.get.map(_._3)
 
-  def getUser(key: Key): TestProgram[Option[User]] =
-    State.get.map(_._1.get(key.userId))
+  def getUsers(keys: Set[Key], when: Long): TestProgram[Vector[User]] =
+    State.get.map { case (users, _, _) => 
+      keys.map(k => users.get(k.userId)).toVector.flatten.filter(oldEnough(_, when))
+    }
 
   def getInactiveUsers(period: TemporalAmount): TestProgram[Vector[User]] = 
     State.get.map(_._1.filter { 

--- a/src/test/scala/com.gu.bonobo/services/interpreters.scala
+++ b/src/test/scala/com.gu.bonobo/services/interpreters.scala
@@ -10,12 +10,12 @@ import model._
 class BonoboServiceInterpreter extends BonoboService[TestProgram] {
   import cats.implicits._
 
-  def getDevelopers: TestProgram[Set[Key]] = State.get.map(_._3)
+  def getUsers(period: TemporalAmount): TestProgram[Vector[User]] = 
+    State.get.map(_._1.filter { 
+      case (_, user) => fixtures.today.minus(period).toInstant.toEpochMilli >= user.extendedAt.getOrElse(user.createdAt)
+    }.values.toVector)
 
-  def getUsers(keys: Set[Key], when: Long): TestProgram[Vector[User]] =
-    State.get.map { case (users, _, _) => 
-      keys.map(k => users.get(k.userId)).toVector.flatten.filter(oldEnough(_, when))
-    }
+  def isDeveloper(user: User): TestProgram[Boolean] = State.pure(true)
 
   def getInactiveUsers(period: TemporalAmount): TestProgram[Vector[User]] = 
     State.get.map(_._1.filter { 

--- a/src/test/scala/com.gu.bonobo/services/package.scala
+++ b/src/test/scala/com.gu.bonobo/services/package.scala
@@ -9,7 +9,7 @@ import model._
 package object services {
   type UserRepo = Map[UserId, User]
   type EmailRepo = Set[Email]
-  type KeyRepo = Vector[Key]
+  type KeyRepo = Set[Key]
   type Repo = (UserRepo, EmailRepo, KeyRepo)
   type TestProgram[A] = State[Repo, A]
 }
@@ -18,7 +18,7 @@ package object fixtures {
     val today = OffsetDateTime.of(2018, 4, 25, 10, 15, 30, 0, ZoneOffset.UTC)
     val todayInstant = today.toInstant
 
-    val keys: Vector[Key] = Vector(
+    val keys: Set[Key] = Set(
         Key(UserId("user0"), "Developer"),
         Key(UserId("user1"), "Developer"),
         Key(UserId("user2"), "Developer"),

--- a/src/test/scala/com.gu.bonobo/services/package.scala
+++ b/src/test/scala/com.gu.bonobo/services/package.scala
@@ -9,13 +9,27 @@ import model._
 package object services {
   type UserRepo = Map[UserId, User]
   type EmailRepo = Set[Email]
-  type Repo = (UserRepo, EmailRepo)
+  type KeyRepo = Vector[Key]
+  type Repo = (UserRepo, EmailRepo, KeyRepo)
   type TestProgram[A] = State[Repo, A]
 }
 
 package object fixtures {
     val today = OffsetDateTime.of(2018, 4, 25, 10, 15, 30, 0, ZoneOffset.UTC)
     val todayInstant = today.toInstant
+
+    val keys: Vector[Key] = Vector(
+        Key(UserId("user0"), "Developer"),
+        Key(UserId("user1"), "Developer"),
+        Key(UserId("user2"), "Developer"),
+        Key(UserId("user3"), "Developer"),
+        Key(UserId("user4"), "Developer"),
+        Key(UserId("user5"), "Developer"),
+        Key(UserId("user6"), "Developer"),
+        Key(UserId("user7"), "Developer"),
+        Key(UserId("user8"), "Developer"),
+        Key(UserId("user9"), "Developer")
+    )
 
     val users: Map[UserId, User] = Map(Seq(
         User.create("user0", "Florence Bowen", "florence.bowen@domain.com", "2012-04-25T10:15:30.00Z"),


### PR DESCRIPTION
We don't want to mistakenly get internal/external/rights managed keys deleted because the email address of their respective user account is not checked or does not exist anymore -- we'll deal with these keys offline.

As a result, gibbons is updated to notify only Developer accounts. This introduces a small difficulty in that the tier is a property of a key, not of a user. So we must first query keys and then only retrieve the corresponding user accounts. Then it's business as usual.
