### PR TITLE
Cleanup OkHttp resources when done

### DIFF
--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -41,14 +41,19 @@ class BonoboInterpreter(config: Settings, logger: LoggingService[Task], dynamoCl
     usersTable.update('id -> UserId.unwrap(user.id), set('remindedAt -> when)).map(_ => ())
   }.map { _ => user.copy(remindedAt = Some(when)) }
 
-  def deleteUser(user: User) = Task {
+  def deleteUser(user: User) = Task.delay {
     val request = new Request.Builder()
       .url(urlGenerator.delete(user))
       .build
-    val response = httpClient.newCall(request).execute()
+    httpClient.newCall(request).execute()
+  }.bracket { response =>
     response.code match {
-      case 200 => ()
-      case _ => throw new Throwable(s"Call to Bonobo failed with ${response.message}: ${response.body}")
+      case 200 => Task(())
+      case _ => Task.raiseError(new Throwable(s"Call to Bonobo failed with ${response.message}: ${response.body}"))
+    }
+  } { response => 
+    Task {
+      response.close()
     }
   }
 


### PR DESCRIPTION
Unless you thoroughly read the JavaDoc, OkHttp will only let you know that it's leaking resources by issuing warnings through its own logger.

It turns out not closing responses can exhaust the thread pool allocated to the client and ultimately shut down the whole application.

Here I'm just making sure the resource is cleaned up no matter the outcome of the computation.