### PR TITLE
Increase throughput with parallelism

### DIFF
--- a/src/main/scala/com.gu.gibbons/UserDidNotAnswer.scala
+++ b/src/main/scala/com.gu.gibbons/UserDidNotAnswer.scala
@@ -1,7 +1,7 @@
 package com.gu.gibbons
 
 // ------------------------------------------------------------------------
-import cats.Monad
+import cats.{ Parallel, Monad }
 import config.Settings
 import java.time.OffsetDateTime
 import model._
@@ -15,12 +15,12 @@ import services._
   * @param bonobo The bonobo service interpreter
   * @param logger The logging service interpreter
   */
-class UserDidNotAnswer[F[_] : Monad](
+class UserDidNotAnswer[F[_] : Monad, G[_]](
   settings: Settings, 
   email: EmailService[F], 
   bonobo: BonoboService[F], 
   override val logger: LoggingService[F]
-) extends Script[F] {
+)(implicit P: Parallel[F, G]) extends Script[F, G] {
     import cats.instances.vector._
     import cats.syntax.functor._
     import cats.syntax.flatMap._

--- a/src/main/scala/com.gu.gibbons/UserReminder.scala
+++ b/src/main/scala/com.gu.gibbons/UserReminder.scala
@@ -1,7 +1,7 @@
 package com.gu.gibbons
 
 // ------------------------------------------------------------------------
-import cats.Monad
+import cats.{ Parallel, Monad }
 import config.Settings
 import java.time.{OffsetDateTime, ZoneOffset}
 import model._
@@ -14,12 +14,12 @@ import services._
   * @param bonobo The bonobo service interpreter
   * @param logger The logging service interpreter
   */
-class UserReminder[F[_] : Monad](
+class UserReminder[F[_] : Monad, G[_]](
   settings: Settings, 
   email: EmailService[F], 
   bonobo: BonoboService[F], 
   override val logger: LoggingService[F]
-) extends Script[F] {
+)(implicit P: Parallel[F, G]) extends Script[F, G] {
     import cats.instances.vector._
     import cats.instances.map._
     import cats.syntax.flatMap._

--- a/src/main/scala/com.gu.gibbons/lambdas/GenericLambda.scala
+++ b/src/main/scala/com.gu.gibbons/lambdas/GenericLambda.scala
@@ -17,7 +17,7 @@ import config._
 import services.interpreters._
 
 abstract class GenericLambda(
-  load: (Settings, EmailInterpreter, BonoboInterpreter, LoggingInterpreter) => Script[Task]
+  load: (Settings, EmailInterpreter, BonoboInterpreter, LoggingInterpreter) => Script[Task, Task.Par]
 )(implicit sched: Scheduler) extends ResourceProvider {
   import cats.implicits._
   import io.circe.syntax._

--- a/src/test/scala/com.gu.bonobo/services/package.scala
+++ b/src/test/scala/com.gu.bonobo/services/package.scala
@@ -1,5 +1,7 @@
 package com.gu.gibbons
 
+import cats.{Applicative, Monad, Parallel}
+import cats.arrow.FunctionK
 import cats.data.State
 import config.Settings
 import java.time.{Instant, OffsetDateTime, ZoneOffset}
@@ -12,6 +14,13 @@ package object services {
   type KeyRepo = Set[Key]
   type Repo = (UserRepo, EmailRepo, KeyRepo)
   type TestProgram[A] = State[Repo, A]
+
+  implicit val parallelProgram = new Parallel[TestProgram, TestProgram] {
+      def parallel = FunctionK.id
+      def sequential = FunctionK.id
+      def applicative = Applicative[TestProgram]
+      def monad = Monad[TestProgram]
+  }
 }
 
 package object fixtures {


### PR DESCRIPTION
There is no reason to run user updates in sequence, as order doesn't matter at all. Plus the running time of a lambda is important, so we leverage the green thread system in Monix to reduce thread blocks.

TODO
- [ ] Throttle calls to Dynamo/Bonobo
- [ ] Test on CODE