### PR TITLE
Re-enable did not answer lambda

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -105,9 +105,6 @@ Resources:
                 ScheduleLambda:
                     Type: Schedule
                     Properties:
-                        # Temporarily postpone this lambda invocation (year 2021 instead of *)
-                        # to prevent the lambda from removing keys in the "Developer" tier that are used in PROD systems.
-                        # This change will be reverted (year * instead of 2021) once we have resolved any such keys.
-                        Schedule: cron(12 14 * * ? 2021) # run daily at 14:12
+                        Schedule: cron(12 14 * * ? *) # run daily at 14:12
                         Input: "false"
         DependsOn: LambdaRole


### PR DESCRIPTION
## What does this change?
Now that we have changed the tier of Developer keys used by services, we can re-enable the lambda which deletes keys under the developer tier.