### PR TITLE
Delete unused oldEnough function

### DIFF
--- a/src/main/scala/com.gu.gibbons/services/BonoboService.scala
+++ b/src/main/scala/com.gu.gibbons/services/BonoboService.scala
@@ -42,8 +42,4 @@ trait BonoboService[F[_]] {
    */
   def deleteUser(user: User): F[Unit]
 
-  def oldEnough(user: User, jadis: Long) =
-    !user.remindedAt.isDefined && (
-      user.extendedAt.exists(_ <= jadis) || !user.extendedAt.isDefined && user.createdAt <= jadis
-    )
 }


### PR DESCRIPTION
The oldEnough function appears to to deprecated and uncalled. The actual selection for delete occurs in the database query?

Removing so future devs don't see it and assume this is the actual logic.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
