### PR TITLE
Postpone auto-cleanup lambda temporarily. And ADD A README!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Gibbons
+
+#### Because monkeys are somehow related to keys: Bonobo, Gibbons ¯\_(ツ)_/¯
+
+## Overview
+Gibbons is comprised of two lambdas that perform API key age monitoring and cleansing.
+
+The `UserReminderLambda`, executes on a daily schedule and scans the database of developer tier API keys looking for any that are sufficiently old to fall under GDPR data deletion rules. The lambda sends emails to users that it finds asking if they wish to retain their key(s).
+
+The `UserDidNotAnswerLambda`, also scheduled for daily execution, returns to keys that the first lambda emailed users about but who haven't responded within two weeks, and deletes them.
+
+Both lambda's schedules are specified in `cloudformation.yaml`
+
+

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -105,6 +105,6 @@ Resources:
                 ScheduleLambda:
                     Type: Schedule
                     Properties:
-                        Schedule: cron(12 14 * * ? *) # run daily at 14:12
+                        Schedule: cron(12 14 * * ? 2031) # run daily at 14:12
                         Input: "false"
         DependsOn: LambdaRole


### PR DESCRIPTION
## What does this change?
Prevent the cleanup schedule running. For a LONG time. This is so we can double-check that the key cleansing process is working as expected.
 
## How to test
Deploy. The reminder lambda should run but the clean-up one shouldn't.

## How can we measure success?
No more keys are deleted for a while.

## Have we considered potential risks?
Risks are minimal. Dormant keys may stick around longer than we'd like but will be swept away when we enable the lambda again.

## Images
N/A

## Accessibility
N/A
