### PR TITLE
Updating inaccurate copy for key deletion email

### DIFF
--- a/src/main/twirl/deleted.scala.html
+++ b/src/main/twirl/deleted.scala.html
@@ -7,8 +7,8 @@
         <p>Dear @to.name,
           <br>
           <br>
-          GDPR requires The Guardian to delete api keys that have not been used in the last 30 months.</p>
-        <p>Two weeks ago, we sent you an email asking whether you were still using your API keys, but haven't heard back from you. As requested by the legislation, your account and keys have been deleted and can no longer be used to access the Guardian's Open Platform.</p>
+          GDPR requires The Guardian to delete API keys that are over 30 months old, unless the user confirms that they wish to keep using their key(s).</p>
+        <p>Two weeks ago, we sent you an email asking whether you were still using your API key(s), but we haven't heard back from you. As requested by the legislation, your account and keys have been deleted and can no longer be used to access the Guardian's Open Platform.</p>
       </td>
     </tr>
     <tr>

--- a/src/main/twirl/reminder.scala.html
+++ b/src/main/twirl/reminder.scala.html
@@ -2,14 +2,14 @@
 @import com.gu.gibbons.utils.UrlGenerator
 @(to: User, gen: UrlGenerator)
 
-@shell("Your API keys are about to expire") {
+@shell("Your API key(s) are about to expire") {
   <table width="100%" cellpadding="0" cellspacing="0">
     <tr>
       <td class="content-block">
         <p>Dear @to.name,
           <br>
           <br>
-          GDPR requires The Guardian to delete api keys that have not been used in the last 30 months. If you wish to retain access to the Guardian's Content API, please confirm <a href="@gen.extend(to)">here</a>, or by copy-pasting the following URL in your browser:</p>
+          GDPR requires The Guardian to delete API keys that are over 30 months old, unless the user confirms that they wish to keep using their key(s). If you wish to retain access to the Guardian's Content API, please confirm <a href="@gen.extend(to)">here</a>, or by copy-pasting the following URL in your browser:</p>
           
         <p>@gen.extend(to)</p>
 
@@ -17,7 +17,7 @@
 
         <p>@gen.delete(to)</p>
 
-        <p><strong>If you do not take action within the next two weeks, your keys will be automatically deleted.</strong></p>
+        <p><strong>If you do not take action within the next two weeks, your key(s) will be automatically deleted.</strong></p>
       </td>
     </tr>
   </table>


### PR DESCRIPTION
## What does this change?
Updates the email copy sent to users to inform them their keys have been deleted, as it incorrectly stated that keys get deleted when they are not used for 30 months, when in fact they get deleted if the user does not respond to the key extension email, regardless of whether they use their key(s) or not.

## How to test
Change is pretty straightforward, there is probably no need to test it unless you really want to :D 
In which case, you can try creating a key and manually changing the creation date to an old date, then wait for the email lambda to run (it does every 24 hours), or attempt to run the lambda manually. (If you think there is a better way to test this -which there probably is- please feel free to suggest.)
