### PR TITLE
Changing getDevelopers function to exclude nondevkey owners

### DIFF
--- a/src/main/scala/com.gu.gibbons/UserReminder.scala
+++ b/src/main/scala/com.gu.gibbons/UserReminder.scala
@@ -31,7 +31,9 @@ class UserReminder[F[_]: Monad](
     for {
       _ <- logger.info(s"Getting all the users older than ${Settings.inactivityPeriod}")
       users <- bonobo.getUsers(now.minus(Settings.inactivityPeriod).toInstant)
+      _ <- logger.info(s"Found ${users.length} users ")
       filteredUsers <- bonobo.getDevelopers(users)
+      _ <- logger.info(s"Found ${filteredUsers.length} developers ")
     } yield filteredUsers
 
   def processUser(now: OffsetDateTime)(user: User): F[(UserId, Option[EmailResult])] = {

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -48,7 +48,7 @@ class BonoboInterpreter(config: Settings,
 
       nonDevKeys <- uss.foldMapM(
         us =>
-          getItems(keysTable, 'bonoboId <= us.map(u => UserId.unwrap(u.id)).toSet and ('tier <= "Internal" or 'tier <= "External" or 'tier <= "RightsManaged"))
+          getItems(keysTable, 'bonoboId <= us.map(u => UserId.unwrap(u.id)).toSet and not('tier <= "Developer"))
       )
       devUserIds = devKeys.map(_.userId).toSet
       nonDevUserIds = nonDevKeys.map(_.userId).toSet

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -13,7 +13,7 @@ import okhttp3.{ OkHttpClient, Request }
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.gu.scanamo._
 import com.gu.scanamo.ops.ScanamoOps
-import com.gu.scanamo.query.{ AndCondition, ConditionExpression }
+import com.gu.scanamo.query.{ ConditionExpression }
 import com.gu.scanamo.syntax._
 
 import com.gu.gibbons.config._
@@ -43,11 +43,12 @@ class BonoboInterpreter(config: Settings,
     for {
       devKeys <- uss.foldMapM(
         us =>
-          getItems(keysTable, AndCondition('bonoboId -> us.map(u => UserId.unwrap(u.id)).toSet, 'tier -> "Developer"))
+          getItems(keysTable, 'bonoboId <= us.map(u => UserId.unwrap(u.id)).toSet and 'tier <= "Developer")
       )
+
       nonDevKeys <- uss.foldMapM(
         us =>
-          getItems(keysTable, AndCondition('bonoboId -> us.map(u => UserId.unwrap(u.id)).toSet, 'tier -> "External"))
+          getItems(keysTable, 'bonoboId <= us.map(u => UserId.unwrap(u.id)).toSet and ('tier <= "Internal" or 'tier <= "External" or 'tier <= "RightsManaged"))
       )
       devUserIds = devKeys.map(_.userId).toSet
       nonDevUserIds = nonDevKeys.map(_.userId).toSet

--- a/src/test/scala/com.gu.bonobo/services/package.scala
+++ b/src/test/scala/com.gu.bonobo/services/package.scala
@@ -21,6 +21,7 @@ package object fixtures {
     val keys: Set[Key] = Set(
         Key(UserId("user0"), "Developer"),
         Key(UserId("user1"), "Developer"),
+        Key(UserId("user1"), "External"),
         Key(UserId("user2"), "Developer"),
         Key(UserId("user3"), "Developer"),
         Key(UserId("user4"), "Developer"),


### PR DESCRIPTION
## What does this change?
Gibbons was deleting non-developer keys due to the fact that it would delete any users who own developer keys regardless of whether they own other keys or not. This PR updates the function that filters the users who we need to notify/delete.

## How to test
Can run in dry mode and confirm the list of users to be deleted does not include non-dev key owners


## How can we measure success?
No more complaints regarding non-developer keys gone missing.

## Have we considered potential risks?
This is a risky change as we could end up deleting the wrong users/keys if the function does not work as we intend it to.
