### PR TITLE
Change dryRun settings to environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,5 @@ The `UserDidNotAnswerLambda`, also scheduled for daily execution, returns to key
 
 Both lambda's schedules are specified in `cloudformation.yaml`
 
+You can run Gibbons in dry mode by setting the environment variable DRY_RUN to true in the lambda configurations in AWS.
 

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -26,6 +26,9 @@ Parameters:
     Salt:
         Description: Secret see to hash IDs
         Type: String
+    DryRun:
+        Description: Flag for running Gibbons in dry mode
+        Type: String
 
 Globals:
     Function:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -31,6 +31,7 @@ Globals:
     Function:
         Environment:
             Variables:
+                DRY_RUN: !Ref DryRun
                 EMAIL_ORIGIN: !Ref Origin
                 SALT: !Ref Salt
                 BONOBO_URL: !Ref BonoboUrl
@@ -91,7 +92,6 @@ Resources:
                     Type: Schedule
                     Properties:
                         Schedule: cron(12 14 * * ? *) # run daily at 14:12
-                        Input: "false"
         DependsOn: LambdaRole
 
     DidNotAnswerLambda:
@@ -106,5 +106,4 @@ Resources:
                     Type: Schedule
                     Properties:
                         Schedule: cron(12 14 * * ? 2031) # run daily at 14:12
-                        Input: "false"
         DependsOn: LambdaRole

--- a/src/main/scala/com.gu.gibbons/Script.scala
+++ b/src/main/scala/com.gu.gibbons/Script.scala
@@ -17,9 +17,12 @@ abstract class Script[F[_]: Monad] {
     for {
       users <- getUsers(now)
       _ <- logger.info(s"Found ${users.length} developers.")
-      ress <- if (dryRun)
+      ress <- if (dryRun) {
+        logger.info("Running in dry mode")
+        logger.info(s"Users found: ${users}")
         Monad[F].pure(users.map(_.id -> (None: Option[EmailResult])).toMap)
-      else users.traverse(processUser(now)).map(_.toMap)
+
+      } else users.traverse(processUser(now)).map(_.toMap)
       _ <- logger.info("aaaand that's a wrap! See you next time.")
     } yield ress
 

--- a/src/main/scala/com.gu.gibbons/Script.scala
+++ b/src/main/scala/com.gu.gibbons/Script.scala
@@ -16,10 +16,9 @@ abstract class Script[F[_]: Monad] {
   def run(now: OffsetDateTime, dryRun: Boolean): F[Map[UserId, Option[EmailResult]]] =
     for {
       users <- getUsers(now)
-      _ <- logger.info(s"Found ${users.length} developers.")
+      _ <- logger.info(s"Found ${users.length} developers. Dry run mode: ${dryRun}")
+      _ <- logger.info(s"Users found: ${users}")
       ress <- if (dryRun) {
-        logger.info("Running in dry mode")
-        logger.info(s"Users found: ${users}")
         Monad[F].pure(users.map(_.id -> (None: Option[EmailResult])).toMap)
 
       } else users.traverse(processUser(now)).map(_.toMap)

--- a/src/main/scala/com.gu.gibbons/config/Settings.scala
+++ b/src/main/scala/com.gu.gibbons/config/Settings.scala
@@ -18,7 +18,8 @@ case class Settings(
   salt: String,
   bonoboUrl: String,
   fromAddress: Email,
-  httpSettings: HttpSettings
+  httpSettings: HttpSettings,
+  dryRun: String
 )
 
 case class HttpSettings(
@@ -43,7 +44,8 @@ object Settings {
      getEnv(env, "BONOBO_KEYS_TABLE"),
      getEnv(env, "SALT"),
      getEnv(env, "BONOBO_URL"),
-     getEnv(env, "EMAIL_ORIGIN").map(Email(_))).mapN(Settings(_, _, _, _, _, _, HttpSettings(2, 5, 5, 10)))
+     getEnv(env, "EMAIL_ORIGIN").map(Email(_)) ,
+     getEnv(env, "DRY_RUN")).mapN(Settings(_, _, _, _, _, _, HttpSettings(2, 5, 5, 10), _))
 
   private def makeRegion(r: String): ValidatedNel[String, Regions] =
     Validated.fromTry {

--- a/src/test/scala/com.gu.bonobo/UserReminderSpec.scala
+++ b/src/test/scala/com.gu.bonobo/UserReminderSpec.scala
@@ -20,7 +20,8 @@ class IntegrationTests extends FlatSpec with Matchers with Inspectors {
         "",
         "",
         Email(""),
-        HttpSettings(0, 0, 0, 0)
+        HttpSettings(0, 0, 0, 0),
+        "false"
     )
 
     val userReminder = new UserReminder(settings, emailService, bonoboService, loggingService)

--- a/src/test/scala/com.gu.bonobo/config/SettingsSpec.scala
+++ b/src/test/scala/com.gu.bonobo/config/SettingsSpec.scala
@@ -9,7 +9,8 @@ class SettingsSpec extends FlatSpec with Matchers with Inspectors {
     "BONOBO_KEYS_TABLE"  -> "Well",
     "SALT"               -> "Are",
     "BONOBO_URL"         -> "You",
-    "EMAIL_ORIGIN"       -> "Doing"
+    "EMAIL_ORIGIN"       -> "Doing",
+    "DRY_RUN"            -> "false"
   )
 
   private val invalidRegion = Map(
@@ -18,7 +19,8 @@ class SettingsSpec extends FlatSpec with Matchers with Inspectors {
     "BONOBO_KEYS_TABLE"  -> "Well",
     "SALT"               -> "Are",
     "BONOBO_URL"         -> "You",
-    "EMAIL_ORIGIN"       -> "Doing"
+    "EMAIL_ORIGIN"       -> "Doing",
+    "DRY_RUN"            -> "false"
   )
 
   private val emptyEnv: Map[String, String] = Map.empty


### PR DESCRIPTION
## What does this change?
This changes dryRun parameter to be set as an environment variable rather than as a lambda event input. This is to avoid the need to cloudform whenever we want to run in dry mode.

## How to test
You can set the DRY_RUN environment variable in the AWS lambda(s). Upon invoking the lambda, you should be able to see a message in the logs that specifies which mode Gibbons is running in.

## How can we measure success?
We should be able to run Gibbons in dry mode and find the information we need about the "would be reminded/deleted" users in the logs

## Have we considered potential risks?
This is a relatively low risk change as it does not change any key-handling logic 
