### PR TITLE
re-enabling gibbons cleanup lambda

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -108,5 +108,5 @@ Resources:
                 ScheduleLambda:
                     Type: Schedule
                     Properties:
-                        Schedule: cron(12 14 * * ? 2031) # run daily at 14:12
+                        Schedule: cron(12 14 * * ? *) # run daily at 14:12
         DependsOn: LambdaRole


### PR DESCRIPTION
## What does this change?
Re-enables the Gibbons cleanup lambda. Both Gibbons lambdas have been set to run in Dry Mode in AWS, so this should be a low-risk change. 