### PR TITLE
New key cleanup logic

### DIFF
--- a/src/main/scala/com.gu.gibbons/Script.scala
+++ b/src/main/scala/com.gu.gibbons/Script.scala
@@ -15,19 +15,18 @@ abstract class Script[F[_]: Monad] {
 
   def run(now: OffsetDateTime, dryRun: Boolean): F[Map[UserId, Option[EmailResult]]] =
     for {
-      users <- getUsers(now)
+      keys <- getKeys(now)
       _ <- logger.info(s"Dry run mode: ${dryRun}")
-      _ <- logger.info(s"Developer key owners: ${users.map(_.id).mkString(", ")}")
+      _ <- logger.info(s"Developer key owners: ${keys.map(_.userId).mkString(", ")}")
       ress <- if (dryRun) {
-        Monad[F].pure(users.map(_.id -> (None: Option[EmailResult])).toMap)
+        Monad[F].pure(keys.map(_.userId -> (None: Option[EmailResult])).toMap)
 
-
-      } else users.traverse(processUser(now)).map(_.toMap)
+      } else keys.traverse(processKey(now)).map(_.toMap)
       _ <- logger.info("aaaand that's a wrap! See you next time.")
     } yield ress
 
-  def getUsers(now: OffsetDateTime): F[Vector[User]]
+  def getKeys(now: OffsetDateTime): F[Vector[Key]]
 
-  def processUser(now: OffsetDateTime)(user: User): F[(UserId, Option[EmailResult])]
+  def processKey(now: OffsetDateTime)(key: Key): F[(UserId, Option[EmailResult])]
 
 }

--- a/src/main/scala/com.gu.gibbons/UserReminder.scala
+++ b/src/main/scala/com.gu.gibbons/UserReminder.scala
@@ -28,6 +28,8 @@ class UserReminder[F[_]: Monad](
     for {
       keys <- bonobo.getPotentiallyInactiveDeveloperKeys(now.minus(Settings.inactivityPeriod).toInstant)
       _ <- logger.info(s"Found ${keys.length} potentially inactive developer keys. ")
+      _ <- logger.info(s"Found these keys ${keys} ")
+
     } yield keys
 
   def processKey(now: OffsetDateTime)(key: Key): F[(UserId, Option[EmailResult])] = {

--- a/src/main/scala/com.gu.gibbons/UserReminder.scala
+++ b/src/main/scala/com.gu.gibbons/UserReminder.scala
@@ -28,8 +28,6 @@ class UserReminder[F[_]: Monad](
     for {
       keys <- bonobo.getPotentiallyInactiveDeveloperKeys(now.minus(Settings.inactivityPeriod).toInstant)
       _ <- logger.info(s"Found ${keys.length} potentially inactive developer keys. ")
-      _ <- logger.info(s"Found these keys ${keys} ")
-
     } yield keys
 
   def processKey(now: OffsetDateTime)(key: Key): F[(UserId, Option[EmailResult])] = {

--- a/src/main/scala/com.gu.gibbons/model/bonobo.scala
+++ b/src/main/scala/com.gu.gibbons/model/bonobo.scala
@@ -63,13 +63,13 @@ object Key {
       (for {
         attrs <- Option(av.getM).map(_.asScala)
         userId <- attrs.get("bonoboId").flatMap(a => Option(a.getS))
-        consumerId <- attrs.get("consumerId").flatMap(a => Option(a.getS))
+        consumerId <- attrs.get("kongConsumerId").flatMap(a => Option(a.getS))
         tier <- attrs.get("tier").flatMap(a => Option(a.getS))
         createdAt <- attrs.get("createdAt").flatMap(a => Option(a.getN).map(_.toLong))
       } yield Key(
         UserId(userId),
-        tier,
         consumerId,
+        tier,
         createdAt,
         attrs.get("remindedAt").flatMap(a => Option(a.getN)).map(_.toLong),
         attrs.get("extendedAt").flatMap(a => Option(a.getN)).map(_.toLong)

--- a/src/main/scala/com.gu.gibbons/model/bonobo.scala
+++ b/src/main/scala/com.gu.gibbons/model/bonobo.scala
@@ -11,16 +11,11 @@ import scala.collection.JavaConverters._
  *
  * @param name the person's name
  * @param email the person's email address
- * @param company the person's company  name
- * @param url the person's company website url
  */
 case class User(
   id: UserId,
   name: String,
-  email: Email,
-  createdAt: Long,
-  remindedAt: Option[Long],
-  extendedAt: Option[Long]
+  email: Email
 )
 
 object User {
@@ -31,15 +26,11 @@ object User {
         id <- attrs.get("id").flatMap(a => Option(a.getS))
         email <- attrs.get("email").flatMap(a => Option(a.getS))
         name <- attrs.get("name").flatMap(a => Option(a.getS))
-        createdAt <- attrs.get("createdAt").flatMap(a => Option(a.getN).map(_.toLong))
       } yield
         User(
           UserId(id),
           name,
           Email(email, Some(name)),
-          createdAt,
-          attrs.get("remindedAt").flatMap(a => Option(a.getN)).map(_.toLong),
-          attrs.get("extendedAt").flatMap(a => Option(a.getN)).map(_.toLong)
         )).fold(Left(MissingProperty): Either[DynamoReadError, User])(Right(_))
 
     // we will never add a new record
@@ -48,22 +39,23 @@ object User {
 
   def create(id: String,
              name: String,
-             email: String,
-             createdAt: String,
-             remindedAt: Option[String] = None,
-             extendedAt: Option[String] = None) =
+             email: String) =
     User(
       UserId(id),
       name,
       Email(email),
-      Instant.parse(createdAt).toEpochMilli,
-      remindedAt.map(Instant.parse(_)).map(_.toEpochMilli),
-      extendedAt.map(Instant.parse(_)).map(_.toEpochMilli)
     )
 }
 
 /** Spurious wrapper to read from Dynamo */
-case class Key(userId: UserId, tier: String)
+case class Key(
+  userId: UserId,
+  consumerId: String,
+  tier: String,
+  createdAt: Long,
+  remindedAt: Option[Long],
+  extendedAt: Option[Long])
+
 
 object Key {
   implicit val format = new DynamoFormat[Key] {
@@ -71,10 +63,33 @@ object Key {
       (for {
         attrs <- Option(av.getM).map(_.asScala)
         userId <- attrs.get("bonoboId").flatMap(a => Option(a.getS))
+        consumerId <- attrs.get("consumerId").flatMap(a => Option(a.getS))
         tier <- attrs.get("tier").flatMap(a => Option(a.getS))
-      } yield Key(UserId(userId), tier)).fold(Left(MissingProperty): Either[DynamoReadError, Key])(Right(_))
+        createdAt <- attrs.get("createdAt").flatMap(a => Option(a.getN).map(_.toLong))
+      } yield Key(
+        UserId(userId),
+        tier,
+        consumerId,
+        createdAt,
+        attrs.get("remindedAt").flatMap(a => Option(a.getN)).map(_.toLong),
+        attrs.get("extendedAt").flatMap(a => Option(a.getN)).map(_.toLong)
+      )).fold(Left(MissingProperty): Either[DynamoReadError, Key])(Right(_))
 
     // will never happen
     def write(k: Key) = new AttributeValue()
   }
+  def create(id: String,
+             consumerId: String,
+             tier: String,
+             createdAt: String,
+             remindedAt: Option[String] = None,
+             extendedAt: Option[String] = None) =
+    Key(
+      UserId(id),
+      consumerId,
+      tier,
+      Instant.parse(createdAt).toEpochMilli,
+      remindedAt.map(Instant.parse(_)).map(_.toEpochMilli),
+      extendedAt.map(Instant.parse(_)).map(_.toEpochMilli)
+    )
 }

--- a/src/main/scala/com.gu.gibbons/model/package.scala
+++ b/src/main/scala/com.gu.gibbons/model/package.scala
@@ -15,4 +15,5 @@ package object model {
   }
 
   type UserId = UserId.T
+
 }

--- a/src/main/scala/com.gu.gibbons/services/BonoboService.scala
+++ b/src/main/scala/com.gu.gibbons/services/BonoboService.scala
@@ -23,6 +23,12 @@ trait BonoboService[F[_]] {
    */
   def getIgnoredReminderKeys(remindedBefore: Instant): F[Vector[Key]]
 
+  /** Get users who own certain keys
+   *
+   * @param keys The keys whose owners we want to notify
+   */
+  def getKeyOwners(keys: Vector[Key]): F[Vector[User]]
+
   /** Start the clock for reminder grace period (default set to 14 days). Users
    * have 14 days to take appropriate action for their
    * keys after receiving the email. If they don't their

--- a/src/main/scala/com.gu.gibbons/services/BonoboService.scala
+++ b/src/main/scala/com.gu.gibbons/services/BonoboService.scala
@@ -23,11 +23,11 @@ trait BonoboService[F[_]] {
    */
   def getIgnoredReminderKeys(remindedBefore: Instant): F[Vector[Key]]
 
-  /** Get users who own certain keys
+  /** Get user who owns certain key
    *
-   * @param keys The keys whose owners we want to notify
+   * @param key The key whose owners we want to notify
    */
-  def getKeyOwners(keys: Vector[Key]): F[Vector[User]]
+  def getKeyOwner(key: Key): F[User]
 
   /** Start the clock for reminder grace period (default set to 14 days). Users
    * have 14 days to take appropriate action for their

--- a/src/main/scala/com.gu.gibbons/services/BonoboService.scala
+++ b/src/main/scala/com.gu.gibbons/services/BonoboService.scala
@@ -9,37 +9,33 @@ import model._
 /** The algebra for interacting with the Bonobo database */
 trait BonoboService[F[_]] {
 
-  /** Get all the users which have been created, or which
-   * have been extended, before `creationDate`
+  /** Get all the developer tier keys which have been created, or which
+   * have been last extended, before certain date
    *
-   * @param creationDate  The date before which a user is
-   *               potentially expired
+   * @param createdBefore  The date before which a key is
+   *               considered potentially inactive
    */
-  def getUsers(creationDate: Instant): F[Vector[User]]
+  def getPotentiallyInactiveDeveloperKeys(createdBefore: Instant): F[Vector[Key]]
 
-  /** Filters a list of users to those who are developers only */
-  def getDevelopers(users: Vector[User]): F[Vector[User]]
-
-  /** Get all the users that are potentially expired but have not
-   * either confirmed or infirmed during the grace period
+  /** Get all the keys where the owner has ignored the reminder email to extend their key
    *
-   * @param reminderDate The date before which a user can  be deleted
+   * @param remindedBefore The date before which a user can  be deleted
    */
-  def getInactiveUsers(reminderDate: Instant): F[Vector[User]]
+  def getIgnoredReminderKeys(remindedBefore: Instant): F[Vector[Key]]
 
-  /** Start the clock for a 14 days grace period. Users
+  /** Start the clock for reminder grace period (default set to 14 days). Users
    * have 14 days to take appropriate action for their
    * keys after receiving the email. If they don't their
-   * account and keys will be automatically deleted.
+   * key will be deleted.
    *
-   * @param user The user
+   * @param key The Key to be either extended or deleted
    */
-  def setRemindedOn(user: User, when: Long): F[User]
+  def setRemindedAt(key: Key, when: Long): F[Key]
 
-  /** Deletes a user and all their keys
+  /** Deletes a key
    *
-   * @param user The user
+   * @param key The key to be deleted
    */
-  def deleteUser(user: User): F[Unit]
+  def deleteKey(key: Key): F[Unit]
 
 }

--- a/src/main/scala/com.gu.gibbons/services/EmailService.scala
+++ b/src/main/scala/com.gu.gibbons/services/EmailService.scala
@@ -4,6 +4,6 @@ package services
 import model._
 
 trait EmailService[F[_]] {
-  def sendReminder(user: User): F[EmailResult]
+  def sendReminder(user: User, key: Key): F[EmailResult]
   def sendDeleted(user: User): F[EmailResult]
 }

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -35,7 +35,11 @@ class BonoboInterpreter(config: Settings,
     for {
       _ <- logger.info(s"Getting all developer keys created before $createdBefore")
       millis = createdBefore.toEpochMilli
-      keys <- getItems(keysTable, ('createdAt <= millis) and ('tier, "Developer"))
+      keys <- getItems(keysTable, ('createdAt <= millis) and
+        ('tier, "Developer") and
+        not(attributeExists('remindedAt)) and
+        (not(attributeExists('extendedAt)) or ('extendedAt <= millis))
+      )
     } yield keys
 
   def getIgnoredReminderKeys(reminderDate: Instant) =

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -35,7 +35,7 @@ class BonoboInterpreter(config: Settings,
     for {
       _ <- logger.info(s"Getting all developer keys created before $createdBefore")
       millis = createdBefore.toEpochMilli
-      keys <- getItems(keysTable, 'createdAt <= millis)
+      keys <- getItems(keysTable, ('createdAt <= millis) and ('tier, "Developer"))
     } yield keys
 
   def getIgnoredReminderKeys(reminderDate: Instant) =

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -35,10 +35,10 @@ class BonoboInterpreter(config: Settings,
     for {
       _ <- logger.info(s"Getting all developer keys created before $createdBefore")
       millis = createdBefore.toEpochMilli
-      _ <- logger.info(s"Millis: $millis")
       keys <- getItems(keysTable,
-        not(attributeExists('remindedAt)) and (not(
-          attributeExists('extendedAt) or 'extendedAt <= millis) and 'createdAt <= millis))
+        not(attributeExists('remindedAt)) and ('extendedAt <= millis or (not(
+          attributeExists('extendedAt)
+        ) and 'createdAt <= millis)) and ('tier beginsWith "Dev"))
     } yield keys
 
   def getIgnoredReminderKeys(reminderDate: Instant) =

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -40,8 +40,11 @@ class BonoboInterpreter(config: Settings,
       _ <- logger.info(s"Devs: $devs")
       developers <- getItems(keysTable, 'tier -> "Developer")
       _ <- logger.info(s"Developers: $developers")
-      oldDevs <- getItems(keysTable, ('tier beginsWith "Dev") and 'createdAt <= millis)
-      _ <- logger.info(s"Old Devs: $oldDevs")
+      oldKeys <- getItems(keysTable, 'createdAt <= millis)
+      _ <- logger.info(s"Old Keys: $oldKeys")
+
+      andConditionKeys <- getItems(keysTable, AndCondition('createdAt <= millis, 'tier -> "Developer"))
+      _ <- logger.info(s"And Condition Keys: $oldKeys")
 
       keys <- getItems(keysTable,
         not(attributeExists('remindedAt)) and ('extendedAt <= millis or (not(

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -33,9 +33,9 @@ class BonoboInterpreter(config: Settings,
 
   def getPotentiallyInactiveDeveloperKeys(createdBefore: Instant) =
     for {
-      _ <- logger.info(s"Getting all developer keys created after $createdBefore")
+      _ <- logger.info(s"Getting all developer keys created before $createdBefore")
       millis = createdBefore.toEpochMilli
-      keys <- getItems(keysTable, 'createdAt >= millis)
+      keys <- getItems(keysTable, 'createdAt <= millis)
     } yield keys
 
   def getIgnoredReminderKeys(reminderDate: Instant) =

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -28,28 +28,14 @@ class BonoboInterpreter(config: Settings,
                         dynamoClient: AmazonDynamoDBAsync,
                         httpClient: OkHttpClient,
                         urlGenerator: UrlGenerator)
-    extends BonoboService[Task] {
+    extends BonoboService[Task]{
 
 
   def getPotentiallyInactiveDeveloperKeys(createdBefore: Instant) =
     for {
-      _ <- logger.info(s"Getting all developer keys created before $createdBefore")
+      _ <- logger.info(s"Getting all developer keys created after $createdBefore")
       millis = createdBefore.toEpochMilli
-      _ <- logger.info(s"Millis: $millis")
-      devs <- getItems(keysTable, 'tier beginsWith "Dev")
-      _ <- logger.info(s"Devs: $devs")
-      developers <- getItems(keysTable, 'tier -> "Developer")
-      _ <- logger.info(s"Developers: $developers")
-      oldKeys <- getItems(keysTable, 'createdAt <= millis)
-      _ <- logger.info(s"Old Keys: $oldKeys")
-
-      andConditionKeys <- getItems(keysTable, AndCondition('createdAt <= millis, 'tier -> "Developer"))
-      _ <- logger.info(s"And Condition Keys: $andConditionKeys")
-
-      keys <- getItems(keysTable,
-        not(attributeExists('remindedAt)) and ('extendedAt <= millis or (not(
-          attributeExists('extendedAt)
-        ) and 'createdAt <= millis)) and ('tier beginsWith "Dev"))
+      keys <- getItems(keysTable, 'createdAt >= millis)
     } yield keys
 
   def getIgnoredReminderKeys(reminderDate: Instant) =

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -35,10 +35,9 @@ class BonoboInterpreter(config: Settings,
     for {
       _ <- logger.info(s"Getting all developer keys created before $createdBefore")
       millis = createdBefore.toEpochMilli
+      _ <- logger.info(s"Millis: $millis")
       keys <- getItems(keysTable,
-        not(attributeExists('remindedAt)) and ('extendedAt <= millis or (not(
-          attributeExists('extendedAt)
-        ) and 'createdAt <= millis)) and ('tier beginsWith "Dev"))
+        not(attributeExists('remindedAt)) and ('createdAt <= millis) and ('tier beginsWith "Dev"))
     } yield keys
 
   def getIgnoredReminderKeys(reminderDate: Instant) =

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -55,14 +55,10 @@ class BonoboInterpreter(config: Settings,
       key.copy(remindedAt = Some(when))
     }
 
-  def getKeyOwners(keys: Vector[Key]) = {
-    val uss = keys.grouped(99).toVector
+  def getKeyOwner(key: Key) = {
     for {
-      users <- uss.foldMapM(
-        us =>
-          getItems(usersTable, 'id -> us.map(u => UserId.unwrap(u.userId)).toSet)
-      )
-    } yield users
+      user <- getItems(usersTable, 'id ->  UserId.unwrap(key.userId))
+    } yield user.toList.head
   }
 
   def deleteKey(key: Key) =
@@ -84,7 +80,7 @@ class BonoboInterpreter(config: Settings,
 
   private val keysTable = Table[Key](config.keysTableName)
 
-  private val usersTable = Table[Key](config.usersTableName)
+  private val usersTable = Table[User](config.usersTableName)
 
   private def run[A](program: ScanamoOps[A]): Task[A] = Task.deferFutureAction { implicit scheduler =>
     ScanamoAsync.exec(dynamoClient)(program)

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -35,10 +35,10 @@ class BonoboInterpreter(config: Settings,
     for {
       _ <- logger.info(s"Getting all developer keys created before $createdBefore")
       millis = createdBefore.toEpochMilli
+      _ <- logger.info(s"Millis: $millis")
       keys <- getItems(keysTable,
-        not(attributeExists('remindedAt)) and ('extendedAt <= millis or (not(
-          attributeExists('extendedAt)
-        ) and 'createdAt <= millis)) and ('tier -> "Developer"))
+        not(attributeExists('remindedAt)) and (not(
+          attributeExists('extendedAt) or 'extendedAt <= millis) and 'createdAt <= millis))
     } yield keys
 
   def getIgnoredReminderKeys(reminderDate: Instant) =

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -44,7 +44,7 @@ class BonoboInterpreter(config: Settings,
       _ <- logger.info(s"Old Keys: $oldKeys")
 
       andConditionKeys <- getItems(keysTable, AndCondition('createdAt <= millis, 'tier -> "Developer"))
-      _ <- logger.info(s"And Condition Keys: $oldKeys")
+      _ <- logger.info(s"And Condition Keys: $andConditionKeys")
 
       keys <- getItems(keysTable,
         not(attributeExists('remindedAt)) and ('extendedAt <= millis or (not(

--- a/src/main/scala/com.gu.gibbons/services/interpreters/EmailInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/EmailInterpreter.scala
@@ -1,5 +1,6 @@
 package com.gu.gibbons.services.interpreters
 
+import cats.syntax.flatMap._
 import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.services.simpleemail.model.{ Destination => SESDestination, Message => SESMessage, _ }
 import com.amazonaws.services.simpleemail.{ AmazonSimpleEmailServiceAsync }
@@ -17,7 +18,7 @@ final class EmailInterpreter(settings: Settings,
                              emailClient: AmazonSimpleEmailServiceAsync,
                              urlGenerator: UrlGenerator)
     extends EmailService[Task] {
-  def sendReminder(user: User) =
+  def sendReminder(user: User, key: Key) =
     sendEmail(user, Settings.reminderSubject, reminderEmail(user))
   def sendDeleted(user: User) =
     sendEmail(user, Settings.deletedSubject, deletedEmail(user))

--- a/src/main/scala/com.gu.gibbons/services/interpreters/EmailInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/EmailInterpreter.scala
@@ -1,13 +1,10 @@
 package com.gu.gibbons.services.interpreters
 
-import cats.syntax.flatMap._
 import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.services.simpleemail.model.{ Destination => SESDestination, Message => SESMessage, _ }
-import com.amazonaws.services.simpleemail.{ AmazonSimpleEmailServiceAsync, AmazonSimpleEmailServiceAsyncClientBuilder }
+import com.amazonaws.services.simpleemail.{ AmazonSimpleEmailServiceAsync }
 import monix.eval.{ Callback, Task }
 import monix.execution.Cancelable
-import monix.java8.eval._
-import scala.collection.JavaConverters._
 import scala.util.{ Failure, Success }
 
 import com.gu.gibbons.config._

--- a/src/main/scala/com.gu.gibbons/services/interpreters/EmailInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/EmailInterpreter.scala
@@ -19,7 +19,7 @@ final class EmailInterpreter(settings: Settings,
                              urlGenerator: UrlGenerator)
     extends EmailService[Task] {
   def sendReminder(user: User, key: Key) =
-    sendEmail(user, Settings.reminderSubject, reminderEmail(user))
+    sendEmail(user, Settings.reminderSubject, reminderEmail(user, key))
   def sendDeleted(user: User) =
     sendEmail(user, Settings.deletedSubject, deletedEmail(user))
 
@@ -52,6 +52,6 @@ final class EmailInterpreter(settings: Settings,
       Cancelable.empty
   }
 
-  private def reminderEmail(user: User) = html.reminder(user, urlGenerator).toString
+  private def reminderEmail(user: User, key: Key) = html.reminder(key: Key, user:User, urlGenerator).toString
   private def deletedEmail(user: User) = html.deleted(user).toString
 }

--- a/src/main/scala/com.gu.gibbons/utils/UrlGenerator.scala
+++ b/src/main/scala/com.gu.gibbons/utils/UrlGenerator.scala
@@ -1,14 +1,13 @@
 package com.gu.gibbons.utils
 
 import com.gu.gibbons.config.Settings
-import com.gu.gibbons.model.{ User, UserId }
-import java.time.Instant
+import com.gu.gibbons.model.{ UserId , Key}
 import java.security.{ MessageDigest, Security }
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 
 abstract class HashGenerator(md: MessageDigest) {
-  def params(user: User, salt: String): String =
-    s"h=${hash(UserId.unwrap(user.id), user.remindedAt.get, salt)}"
+  def params(key: Key, salt: String): String =
+    s"h=${hash(UserId.unwrap(key.userId), key.remindedAt.get, salt)}"
 
   def hash(id: String, when: Long, salt: String): String = {
     val hash = id + when.toString + salt
@@ -17,12 +16,13 @@ abstract class HashGenerator(md: MessageDigest) {
 }
 
 class UrlGenerator(settings: Settings, md: MessageDigest) extends HashGenerator(md) {
-  private def url(action: String, user: User) =
-    s"${settings.bonoboUrl}/user/${UserId.unwrap(user.id)}/${action}?${params(user, settings.salt)}"
+  private def url(action: String, key: Key) =
+    s"${settings.bonoboUrl}/user/${UserId.unwrap(key.userId)}/${action}?${params(key, settings.salt)}"
 
-  def extend(user: User): String = url("extend", user)
+  def extendKey(key: Key): String = url("extend-key", key)
 
-  def delete(user: User): String = url("delete", user)
+  def deleteKey(key: Key): String = url("delete-key", key)
+
 }
 
 object UrlGenerator {

--- a/src/main/scala/com.gu.gibbons/utils/UrlGenerator.scala
+++ b/src/main/scala/com.gu.gibbons/utils/UrlGenerator.scala
@@ -7,7 +7,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 
 abstract class HashGenerator(md: MessageDigest) {
   def params(key: Key, salt: String): String =
-    s"h=${hash(UserId.unwrap(key.userId), key.remindedAt.get, salt)}"
+    s"h=${hash(key.consumerId, key.remindedAt.get, salt)}"
 
   def hash(id: String, when: Long, salt: String): String = {
     val hash = id + when.toString + salt
@@ -17,7 +17,7 @@ abstract class HashGenerator(md: MessageDigest) {
 
 class UrlGenerator(settings: Settings, md: MessageDigest) extends HashGenerator(md) {
   private def url(action: String, key: Key) =
-    s"${settings.bonoboUrl}/user/${UserId.unwrap(key.userId)}/${action}?${params(key, settings.salt)}"
+    s"${settings.bonoboUrl}/user/${key.consumerId}/${action}?${params(key, settings.salt)}"
 
   def extendKey(key: Key): String = url("extend-key", key)
 

--- a/src/main/twirl/deleted.scala.html
+++ b/src/main/twirl/deleted.scala.html
@@ -7,8 +7,8 @@
         <p>Dear @to.name,
           <br>
           <br>
-          GDPR requires The Guardian to delete API keys that are over 30 months old, unless the user confirms that they wish to keep using their key(s).</p>
-        <p>Two weeks ago, we sent you an email asking whether you were still using your API key(s), but we haven't heard back from you. As requested by the legislation, your account and keys have been deleted and can no longer be used to access the Guardian's Open Platform.</p>
+          GDPR requires The Guardian to delete API keys that are over 30 months old, unless the user confirms that they wish to keep using their key.</p>
+        <p>Two weeks ago, we sent you an email asking whether you were still using your API key, but we haven't heard back from you. As requested by the legislation, your key has been deleted and can no longer be used to access the Guardian's Open Platform.</p>
       </td>
     </tr>
     <tr>

--- a/src/main/twirl/reminder.scala.html
+++ b/src/main/twirl/reminder.scala.html
@@ -1,23 +1,23 @@
-@import com.gu.gibbons.model.User
+@import com.gu.gibbons.model.{Key, User}
 @import com.gu.gibbons.utils.UrlGenerator
-@(to: User, gen: UrlGenerator)
+@(key: Key, user: User, gen: UrlGenerator)
 
-@shell("Your API key(s) are about to expire") {
+@shell("Your API key is about to expire") {
   <table width="100%" cellpadding="0" cellspacing="0">
     <tr>
       <td class="content-block">
-        <p>Dear @to.name,
+        <p>Dear @user.name,
           <br>
           <br>
-          GDPR requires The Guardian to delete API keys that are over 30 months old, unless the user confirms that they wish to keep using their key(s). If you wish to retain access to the Guardian's Content API, please confirm <a href="@gen.extend(to)">here</a>, or by copy-pasting the following URL in your browser:</p>
+          GDPR requires The Guardian to delete API keys that are over 30 months old, unless the user confirms that they wish to keep using their key. If you wish to retain access to the Guardian's Content API, please confirm <a href="@gen.extendKey(key)">here</a>, or by copy-pasting the following URL in your browser:</p>
           
-        <p>@gen.extend(to)</p>
+        <p>@gen.extendKey(key)</p>
 
-        <p>If you do not wish to retain access, please confirm <a href="@gen.delete(to)">here</a>, or by copy-pasting the following URL in your browser:</p>
+        <p>If you do not wish to retain access, please confirm <a href="@gen.deleteKey(key)">here</a>, or by copy-pasting the following URL in your browser:</p>
 
-        <p>@gen.delete(to)</p>
+        <p>@gen.deleteKey(key)</p>
 
-        <p><strong>If you do not take action within the next two weeks, your key(s) will be automatically deleted.</strong></p>
+        <p><strong>If you do not take action within the next two weeks, your key will be automatically deleted.</strong></p>
       </td>
     </tr>
   </table>

--- a/src/test/scala/com.gu.bonobo/UserReminderSpec.scala
+++ b/src/test/scala/com.gu.bonobo/UserReminderSpec.scala
@@ -28,17 +28,17 @@ class IntegrationTests extends FlatSpec with Matchers with Inspectors {
     val userDidNotAnswer = new UserDidNotAnswer(settings, emailService, bonoboService, loggingService)
 
     "The Reminder service" should "send reminders, duh" in {
-        val ((newUsers, emailService, _), sentEmails) = userReminder.run(today, false).run((users, Set.empty, keys)).value
-        val remindedUsers = newUsers.filter(_._2.remindedAt.exists(_ == todayInstant.toEpochMilli)).map(_._2.id).toSet
-        forAll(remindedUsers) { u => 
-            emailService should contain (users(u).email)  
+        val ((_, emailService, newKeys), sentEmails) = userReminder.run(today, false).run((users, Set.empty, keys)).value
+        val remindedKeys = newKeys.filter(_._2.remindedAt.exists(_ == todayInstant.toEpochMilli)).map(_._2.userId).toSet
+        forAll(remindedKeys) { u =>
+            emailService should contain (users(u).email)
         }
         sentEmails should not be empty
     }
 
     "The DidNotAnswer service" should "remove expired keys" in {
-        val ((newUsers, emailService, _), _) = userDidNotAnswer.run(today, false).run((users, Set.empty, keys)).value
-        val deletedKeys = newUsers.filter(_._2.remindedAt.exists(t => today.minus(Settings.gracePeriod).toInstant.toEpochMilli >= t))
+        val ((_, emailService, newKeys), _) = userDidNotAnswer.run(today, false).run((users, Set.empty, keys)).value
+        val deletedKeys = newKeys.filter(_._2.remindedAt.exists(t => today.minus(Settings.gracePeriod).toInstant.toEpochMilli >= t))
         
         deletedKeys.size shouldBe 0
     }

--- a/src/test/scala/com.gu.bonobo/services/interpreters.scala
+++ b/src/test/scala/com.gu.bonobo/services/interpreters.scala
@@ -9,7 +9,7 @@ import model._
 class BonoboServiceInterpreter extends BonoboService[TestProgram] {
   import cats.implicits._
 
-  def getPotentiallyInactiveKeys(createdBefore: Instant): TestProgram[Vector[Key]] =
+  def getPotentiallyInactiveDeveloperKeys(createdBefore: Instant): TestProgram[Vector[Key]] =
     State.get.map(_._3.filter {
       case (_, key) => createdBefore.toEpochMilli >= key.extendedAt.getOrElse(key.createdAt)
     }.values.toVector)
@@ -22,13 +22,13 @@ class BonoboServiceInterpreter extends BonoboService[TestProgram] {
   def getKeyOwner(key: Key): TestProgram[User] =
     State.get.map(_._1.filter {
       case (_, user) => user.id == key.userId
-    }.values.toVector)
+    }.values.toVector.head)
 
   def setRemindedAt(key: Key, when: Long): TestProgram[Key] =
     State.get.flatMap { case (users, emails, keys) =>
       val newKey = keys(key.consumerId).copy(remindedAt = Some(when))
       for {
-        _ <- State.set((users, emails, keys.updated(key.consumerId, newKey),))
+        _ <- State.set((users, emails, keys.updated(key.consumerId, newKey)))
       } yield newKey
     }
 

--- a/src/test/scala/com.gu.bonobo/services/interpreters.scala
+++ b/src/test/scala/com.gu.bonobo/services/interpreters.scala
@@ -9,29 +9,32 @@ import model._
 class BonoboServiceInterpreter extends BonoboService[TestProgram] {
   import cats.implicits._
 
-  def getUsers(creationDate: Instant): TestProgram[Vector[User]] =
-    State.get.map(_._1.filter { 
-      case (_, user) => creationDate.toEpochMilli >= user.extendedAt.getOrElse(user.createdAt)
+  def getPotentiallyInactiveKeys(createdBefore: Instant): TestProgram[Vector[Key]] =
+    State.get.map(_._3.filter {
+      case (_, key) => createdBefore.toEpochMilli >= key.extendedAt.getOrElse(key.createdAt)
     }.values.toVector)
 
-  def getDevelopers(users: Vector[User]): TestProgram[Vector[User]] = State.pure(users)
-
-  def getInactiveUsers(reminderDate: Instant): TestProgram[Vector[User]] =
-    State.get.map(_._1.filter { 
-      case (_, user) => user.remindedAt.exists(r => reminderDate.toEpochMilli >= r)
+  def getIgnoredReminderKeys(remindedBefore: Instant): TestProgram[Vector[Key]] =
+    State.get.map(_._3.filter {
+      case (_, key) => remindedBefore.toEpochMilli >= key.remindedAt.getOrElse(key.createdAt)
     }.values.toVector)
 
-  def setRemindedOn(user: User, when: Long): TestProgram[User] = 
+  def getKeyOwner(key: Key): TestProgram[User] =
+    State.get.map(_._1.filter {
+      case (_, user) => user.id == key.userId
+    }.values.toVector)
+
+  def setRemindedAt(key: Key, when: Long): TestProgram[Key] =
     State.get.flatMap { case (users, emails, keys) =>
-      val newUser = users(user.id).copy(remindedAt = Some(when))
+      val newKey = keys(key.consumerId).copy(remindedAt = Some(when))
       for {
-        _ <- State.set((users.updated(user.id, newUser), emails, keys))
-      } yield newUser
+        _ <- State.set((users, emails, keys.updated(key.consumerId, newKey),))
+      } yield newKey
     }
 
-  def deleteUser(user: User): TestProgram[Unit] = for {
+  def deleteKey(key: Key): TestProgram[Unit] = for {
     s <- State.get
-    _ <- State.set((s._1 - user.id, s._2, s._3))
+    _ <- State.set((s._1, s._2, s._3 - key.consumerId))
   } yield ()
 }
 
@@ -58,7 +61,7 @@ class EmailServiceInterpreter extends EmailService[TestProgram] {
       |${user.email.email}""".stripMargin
   )
 
-  def sendReminder(user: User): TestProgram[EmailResult] = for { 
+  def sendReminder(user: User, key: Key): TestProgram[EmailResult] = for {
     s <- State.get
     _ <- State.set((s._1, s._2 + user.email, s._3))
   } yield result("Reminder email", user)

--- a/src/test/scala/com.gu.bonobo/services/package.scala
+++ b/src/test/scala/com.gu.bonobo/services/package.scala
@@ -19,28 +19,28 @@ package object fixtures {
     val todayInstant = today.toInstant
 
     val keys: Set[Key] = Set(
-        Key(UserId("user0"), "Developer"),
-        Key(UserId("user1"), "Developer"),
-        Key(UserId("user2"), "Developer"),
-        Key(UserId("user3"), "Developer"),
-        Key(UserId("user4"), "Developer"),
-        Key(UserId("user5"), "Developer"),
-        Key(UserId("user6"), "Developer"),
-        Key(UserId("user7"), "Developer"),
-        Key(UserId("user8"), "Developer"),
-        Key(UserId("user9"), "Developer")
+        Key.create("user0", "fake-consumer-id", "Developer", "2012-04-25T10:15:30.00Z"),
+        Key.create("user1", "fake-consumer-id", "Developer", "2015-08-25T10:15:30.00Z", Some("2015-08-25T10:15:30.00Z")),
+        Key.create("user2", "fake-consumer-id", "Developer", "2012-04-25T10:15:30.00Z"),
+        Key.create("user3", "fake-consumer-id", "Developer", "2003-02-25T10:15:30.00Z", Some("2017-08-25T10:15:30.00Z"), Some("2018-04-01T10:15:30.00Z")),
+        Key.create("user4", "fake-consumer-id", "Developer", "2012-04-25T10:15:30.00Z"),
+        Key.create("user5", "fake-consumer-id", "Developer", "2012-04-25T10:15:30.00Z", Some("2015-08-25T10:15:30.00Z"), Some("2015-08-25T10:15:30.00Z")),
+        Key.create("user6", "fake-consumer-id", "Developer",  "2012-04-25T10:15:30.00Z", Some("2017-08-25T10:15:30.00Z")),
+        Key.create("user7", "fake-consumer-id", "Developer",  "2012-04-25T10:15:30.00Z", Some("2015-08-25T10:15:30.00Z"), Some("2018-04-25T10:15:30.00Z")),
+        Key.create("user8", "fake-consumer-id", "Developer", "2012-04-25T10:15:30.00Z"),
+        Key.create("user9", "fake-consumer-id", "Developer",  "2012-04-25T10:15:30.00Z", Some("2015-08-25T10:15:30.00Z"), Some("2018-04-01T10:15:30.00Z"))
     )
 
     val users: Map[UserId, User] = Map(Seq(
-        User.create("user0", "Florence Bowen", "florence.bowen@domain.com", "2012-04-25T10:15:30.00Z"),
-        User.create("user1", "Margaret Woolley", "margaret.woolley@domain.com", "2015-08-25T10:15:30.00Z", Some("2015-08-25T10:15:30.00Z")),
-        User.create("user2", "Ruth Clay", "ruth.clay@domain.com", "2012-04-25T10:15:30.00Z"),
-        User.create("user3", "Anna Derrick", "anna.derrick@domain.com", "2003-02-25T10:15:30.00Z", Some("2017-08-25T10:15:30.00Z"), Some("2018-04-01T10:15:30.00Z")),
-        User.create("user4", "Frances Li", "frances.li@domain.com", "2012-04-25T10:15:30.00Z"),
-        User.create("user5", "Mildred Blundell", "mildred.blundell@domain.com", "2012-04-25T10:15:30.00Z", Some("2015-08-25T10:15:30.00Z"), Some("2015-08-25T10:15:30.00Z")),
-        User.create("user6", "Elizabeth Blaese", "elizabeth.blaese@domain.com", "2012-04-25T10:15:30.00Z", Some("2017-08-25T10:15:30.00Z")),
-        User.create("user7", "Marie Wolfe", "marie.wolfe@domain.com", "2012-04-25T10:15:30.00Z", Some("2015-08-25T10:15:30.00Z"), Some("2018-04-25T10:15:30.00Z")),
-        User.create("user8", "Dorothy Robbins", "dorothy.robbins@domain.com", "2012-04-25T10:15:30.00Z"),
-        User.create("user9", "Mary Allen", "mary.allen@domain.com", "2012-04-25T10:15:30.00Z", Some("2015-08-25T10:15:30.00Z"), Some("2018-04-01T10:15:30.00Z"))
+        User.create("user0", "Florence Bowen", "florence.bowen@domain.com"),
+        User.create("user1", "Margaret Woolley", "margaret.woolley@domain.com"),
+        User.create("user2", "Ruth Clay", "ruth.clay@domain.com"),
+        User.create("user3", "Anna Derrick", "anna.derrick@domain.com"),
+        User.create("user4", "Frances Li", "frances.li@domain.com"),
+        User.create("user5", "Mildred Blundell", "mildred.blundell@domain.com"),
+        User.create("user6", "Elizabeth Blaese", "elizabeth.blaese@domain.com"),
+        User.create("user7", "Marie Wolfe", "marie.wolfe@domain.com"),
+        User.create("user8", "Dorothy Robbins", "dorothy.robbins@domain.com"),
+        User.create("user9", "Mary Allen", "mary.allen@domain.com")
     ).map(user => user.id -> user): _*)
 }

--- a/src/test/scala/com.gu.bonobo/services/package.scala
+++ b/src/test/scala/com.gu.bonobo/services/package.scala
@@ -9,7 +9,7 @@ import model._
 package object services {
   type UserRepo = Map[UserId, User]
   type EmailRepo = Set[Email]
-  type KeyRepo = Set[Key]
+  type KeyRepo = Map[String, Key]
   type Repo = (UserRepo, EmailRepo, KeyRepo)
   type TestProgram[A] = State[Repo, A]
 }
@@ -18,18 +18,18 @@ package object fixtures {
     val today = OffsetDateTime.of(2018, 4, 25, 10, 15, 30, 0, ZoneOffset.UTC)
     val todayInstant = today.toInstant
 
-    val keys: Set[Key] = Set(
-        Key.create("user0", "fake-consumer-id", "Developer", "2012-04-25T10:15:30.00Z"),
-        Key.create("user1", "fake-consumer-id", "Developer", "2015-08-25T10:15:30.00Z", Some("2015-08-25T10:15:30.00Z")),
-        Key.create("user2", "fake-consumer-id", "Developer", "2012-04-25T10:15:30.00Z"),
-        Key.create("user3", "fake-consumer-id", "Developer", "2003-02-25T10:15:30.00Z", Some("2017-08-25T10:15:30.00Z"), Some("2018-04-01T10:15:30.00Z")),
-        Key.create("user4", "fake-consumer-id", "Developer", "2012-04-25T10:15:30.00Z"),
-        Key.create("user5", "fake-consumer-id", "Developer", "2012-04-25T10:15:30.00Z", Some("2015-08-25T10:15:30.00Z"), Some("2015-08-25T10:15:30.00Z")),
-        Key.create("user6", "fake-consumer-id", "Developer",  "2012-04-25T10:15:30.00Z", Some("2017-08-25T10:15:30.00Z")),
-        Key.create("user7", "fake-consumer-id", "Developer",  "2012-04-25T10:15:30.00Z", Some("2015-08-25T10:15:30.00Z"), Some("2018-04-25T10:15:30.00Z")),
-        Key.create("user8", "fake-consumer-id", "Developer", "2012-04-25T10:15:30.00Z"),
-        Key.create("user9", "fake-consumer-id", "Developer",  "2012-04-25T10:15:30.00Z", Some("2015-08-25T10:15:30.00Z"), Some("2018-04-01T10:15:30.00Z"))
-    )
+    val keys: Map[String, Key] = Map(Seq(
+        Key.create("user0", "consumerId0", "Developer", "2012-04-25T10:15:30.00Z"),
+        Key.create("user1", "consumerId1", "Developer", "2015-08-25T10:15:30.00Z", Some("2015-08-25T10:15:30.00Z")),
+        Key.create("user2", "consumerId2", "Developer", "2012-04-25T10:15:30.00Z"),
+        Key.create("user3", "consumerId3", "Developer", "2003-02-25T10:15:30.00Z", Some("2017-08-25T10:15:30.00Z"), Some("2018-04-01T10:15:30.00Z")),
+        Key.create("user4", "consumerId4", "Developer", "2012-04-25T10:15:30.00Z"),
+        Key.create("user5", "consumerId5", "Developer", "2012-04-25T10:15:30.00Z", Some("2015-08-25T10:15:30.00Z"), Some("2015-08-25T10:15:30.00Z")),
+        Key.create("user6", "consumerId6", "Developer",  "2012-04-25T10:15:30.00Z", Some("2017-08-25T10:15:30.00Z")),
+        Key.create("user7", "consumerId7", "Developer",  "2012-04-25T10:15:30.00Z", Some("2015-08-25T10:15:30.00Z"), Some("2018-04-25T10:15:30.00Z")),
+        Key.create("user8", "consumerId8", "Developer", "2012-04-25T10:15:30.00Z"),
+        Key.create("user9", "consumerId9", "Developer",  "2012-04-25T10:15:30.00Z", Some("2015-08-25T10:15:30.00Z"), Some("2018-04-01T10:15:30.00Z"))
+    ).map(key => key.consumerId -> key): _*)
 
     val users: Map[UserId, User] = Map(Seq(
         User.create("user0", "Florence Bowen", "florence.bowen@domain.com"),


### PR DESCRIPTION
 ## What does this change?
This moves the developer key extension/deletion logic from the User level to the Key level. This was done to avoid deleting a user and all their keys. Once a user doesn't have any keys left they will be deleted automatically. The user deletion logic has been moved from Gibbons to Bonobo.

## How to test
To be end-to-end tested on CODE

## How can we measure success?
Users should be able to extend/delete their developer keys.

## Have we considered potential risks?
This is a major change to the way we handle key cleanup logic, so we need to make sure we didn't break anything.
