### PR TITLE
Send reminders to everyone

### DIFF
--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -37,7 +37,6 @@ class BonoboInterpreter(config: Settings,
       millis = createdBefore.toEpochMilli
       keys <- getItems(keysTable, ('createdAt <= millis) and
         ('tier, "Developer") and
-        not(attributeExists('remindedAt)) and
         (not(attributeExists('extendedAt)) or ('extendedAt <= millis))
       )
     } yield keys


### PR DESCRIPTION
Removes a condition temporarily in order to resend emails to everyone regardless of whether they've already been reminded or not. This was done because some reminder emails went out while we were transitioning from the old key cleanup logic to the new.