### PR TITLE
Fix bug in key deletion email

### DIFF
--- a/src/main/scala/com.gu.gibbons/UserDidNotAnswer.scala
+++ b/src/main/scala/com.gu.gibbons/UserDidNotAnswer.scala
@@ -33,8 +33,8 @@ class UserDidNotAnswer[F[_]: Monad](
 
   def processKey(now: OffsetDateTime)(key: Key): F[(UserId, Option[EmailResult])] =
     for {
-      _ <- bonobo.deleteKey(key)
       keyOwner <- bonobo.getKeyOwner(key)
+      _ <- bonobo.deleteKey(key)
       res <- email.sendDeleted(keyOwner)
     } yield key.userId -> Some(res)
 


### PR DESCRIPTION
## What does this change?

Fixes a bug where we were attempting to retrieve the key's owner after deleting the key. We need to know the key owner so that we could notify them that their key has been deleted. Our failure to get the key owner was throwing an exception meaning the users who ignored the reminders weren't being notified that their keys were deleted. I switched the order to get the key owner and THEN delete the key.

## How to test

This needs to be tested on PROD (as our CODE environment doesn't send emails), however it wouldn't break anything even in the event that the fix doesn't work.

## How can we measure success?

Clean up lambda should send deletion emails successfully.

## Have we considered potential risks?

This is a low risk change.
