### PR TITLE
Bumping log4j and lambdalog4j

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,9 +3,9 @@ import sbt._
 object Dependencies {
   lazy val scalaTest = "org.scalatest"            %% "scalatest"             % "3.0.5"
   lazy val cats = "org.typelevel"                 %% "cats-core"             % "1.1.0"
-  lazy val lambdaLog4J = "com.amazonaws"          % "aws-lambda-java-log4j2" % "1.0.0"
-  lazy val log4jCore = "org.apache.logging.log4j" % "log4j-core"             % "2.8.2"
-  lazy val log4jApi = "org.apache.logging.log4j"  % "log4j-api"              % "2.8.2"
+  lazy val lambdaLog4J = "com.amazonaws"          % "aws-lambda-java-log4j2" % "1.3.0"
+  lazy val log4jCore = "org.apache.logging.log4j" % "log4j-core"             % "2.15.0"
+  lazy val log4jApi = "org.apache.logging.log4j"  % "log4j-api"              % "2.15.0"
   lazy val scanamo = "com.gu"                     %% "scanamo"               % "1.0.0-M7"
   lazy val okhttp = "com.squareup.okhttp3"        % "okhttp"                 % "3.10.0"
   lazy val bouncyCastle = "org.bouncycastle"      % "bcpkix-jdk15on"         % "1.59"


### PR DESCRIPTION
## What does this change?

This bumps the log4j version to latest "2.15.0", as well as lambdalog4j to version "1.3.0" as per AWS guidance here:
https://aws.amazon.com/security/security-bulletins/AWS-2021-005/

These changes are required to mitigate an RCE exploit found in log4j. More details here:
https://www.lunasec.io/docs/blog/log4j-zero-day/#how-the-exploit-works

