### PR TITLE
bump log4j and lambda log4j

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,9 +3,9 @@ import sbt._
 object Dependencies {
   lazy val scalaTest = "org.scalatest"            %% "scalatest"             % "3.0.5"
   lazy val cats = "org.typelevel"                 %% "cats-core"             % "1.1.0"
-  lazy val lambdaLog4J = "com.amazonaws"          % "aws-lambda-java-log4j2" % "1.3.0"
-  lazy val log4jCore = "org.apache.logging.log4j" % "log4j-core"             % "2.15.0"
-  lazy val log4jApi = "org.apache.logging.log4j"  % "log4j-api"              % "2.15.0"
+  lazy val lambdaLog4J = "com.amazonaws"          % "aws-lambda-java-log4j2" % "1.4.0"
+  lazy val log4jCore = "org.apache.logging.log4j" % "log4j-core"             % "2.16.0"
+  lazy val log4jApi = "org.apache.logging.log4j"  % "log4j-api"              % "2.16.0"
   lazy val scanamo = "com.gu"                     %% "scanamo"               % "1.0.0-M7"
   lazy val okhttp = "com.squareup.okhttp3"        % "okhttp"                 % "3.10.0"
   lazy val bouncyCastle = "org.bouncycastle"      % "bcpkix-jdk15on"         % "1.59"


### PR DESCRIPTION
[## Describe your changes
We're bumping `log4j` to `2.16.0` and `lambda log4j` to `1.4.0`
* What has changed
  * `dependencies.scala`

* Why is this change required
   * Security patches
   
## Data
This change 
- [ ] does
- [x] does not
impact the CAPI data model

## Dashboards
This change can be tracked on a dashboard
- [x] No
- [ ] Yes (provide link)

If it's not obvious, consider adding a screenshot showing what to look out for on the graph/dashboard

## Testing
Tests have been run on 
- [ ] Local instance(s)
- [ ] CODE
- [ ] PROD
- [x] TeamCity
- [ ] None of the above

## Risk Assessment
This is really useful to help someone understand the scope of the change and, perhaps more importantly, rollback 
considerations you've thought about in case something goes wrong.

Say as much as possible about internal and external dependencies that might be impacted by this change.

### This change is considered to be
- [ ] Risk-free
- [x] Low risk
- [ ] Medium risk
- [ ] High risk

Please give a brief assessment here

If there were significant issues we'd expect problems during the build process. That was clean, so now we're moving to testing in CODE to make sure the basics are all still good.


]