### PR TITLE
Temporarily disable key deletion emails

### DIFF
--- a/src/main/scala/com.gu.gibbons/UserDidNotAnswer.scala
+++ b/src/main/scala/com.gu.gibbons/UserDidNotAnswer.scala
@@ -33,9 +33,9 @@ class UserDidNotAnswer[F[_]: Monad](
 
   def processKey(now: OffsetDateTime)(key: Key): F[(UserId, Option[EmailResult])] =
     for {
-      keyOwner <- bonobo.getKeyOwner(key)
+      //keyOwner <- bonobo.getKeyOwner(key)
       _ <- bonobo.deleteKey(key)
-      res <- email.sendDeleted(keyOwner)
-    } yield key.userId -> Some(res)
+      //res <- email.sendDeleted(keyOwner)
+    } yield key.userId -> None
 
 }


### PR DESCRIPTION
## What does this change?

This temporarily disables sending key deletion emails to users in attempt to reduce the amount of spam complaints 

## How to test

Tested on CODE but as our CODE environment doesn't send emails, we would need to deploy to PROD and monitor.

## How can we measure success?

We need to monitor the percentage of complaints we get with AWS and see improvements.

## Have we considered potential risks?

This is a low-risk change.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
