### PR TITLE
Use lastUsed dates for reminders instead of createdAt dates

### DIFF
--- a/src/main/scala/com.gu.gibbons/model/bonobo.scala
+++ b/src/main/scala/com.gu.gibbons/model/bonobo.scala
@@ -55,7 +55,8 @@ case class Key(
   tier: String,
   createdAt: Long,
   remindedAt: Option[Long],
-  extendedAt: Option[Long])
+  extendedAt: Option[Long],
+  lastUsedAt: Option[Long])
 
 
 object Key {
@@ -75,7 +76,8 @@ object Key {
         tier,
         createdAt,
         attrs.get("remindedAt").flatMap(a => Option(a.getN)).map(_.toLong),
-        attrs.get("extendedAt").flatMap(a => Option(a.getN)).map(_.toLong)
+        attrs.get("extendedAt").flatMap(a => Option(a.getN)).map(_.toLong),
+        attrs.get("lastUsedAt").flatMap(a => Option(a.getN)).map(_.toLong),
       )).fold(Left(MissingProperty): Either[DynamoReadError, Key])(Right(_))
 
     // will never happen
@@ -87,7 +89,8 @@ object Key {
              tier: String,
              createdAt: String,
              remindedAt: Option[String] = None,
-             extendedAt: Option[String] = None) =
+             extendedAt: Option[String] = None,
+             lastUsedAt: Option[String] = None) =
     Key(
       UserId(id),
       rangeKey,
@@ -95,6 +98,7 @@ object Key {
       tier,
       Instant.parse(createdAt).toEpochMilli,
       remindedAt.map(Instant.parse(_)).map(_.toEpochMilli),
-      extendedAt.map(Instant.parse(_)).map(_.toEpochMilli)
+      extendedAt.map(Instant.parse(_)).map(_.toEpochMilli),
+      lastUsedAt.map(Instant.parse(_)).map(_.toEpochMilli),
     )
 }

--- a/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
+++ b/src/main/scala/com.gu.gibbons/services/interpreters/BonoboInterpreter.scala
@@ -31,11 +31,11 @@ class BonoboInterpreter(config: Settings,
     extends BonoboService[Task]{
 
 
-  def getPotentiallyInactiveDeveloperKeys(createdBefore: Instant) =
+  def getPotentiallyInactiveDeveloperKeys(lastUsedBefore: Instant) =
     for {
-      _ <- logger.info(s"Getting all developer keys created before $createdBefore")
-      millis = createdBefore.toEpochMilli
-      keys <- getItems(keysTable, ('createdAt <= millis) and
+      _ <- logger.info(s"Getting all developer keys last used before $lastUsedBefore")
+      millis = lastUsedBefore.toEpochMilli
+      keys <- getItems(keysTable, ('lastUsedTimestamp <= millis) and
         ('tier, "Developer") and
         not(attributeExists('remindedAt)) and
         (not(attributeExists('extendedAt)) or ('extendedAt <= millis))


### PR DESCRIPTION
Co-authored-by: Divya Bhatt <divya.bhatt@guardian.co.uk>

## What does this change?

This changes the Gibbons `UserReminderLambda` to use the `lastUsedTimestamp` added by `KongKeyMon` instead of using the key's `createdAt` date. _**Merging this is pending deciding what the inactivity period should be and also deciding what to do about existing keys that do not have the `lastUsedTimestamp.`**_

## How to test

This can be deployed to CODE or PROD and tested with `DryRun`.

## How can we measure success?

User reminder emails should be completely driven by key usage and not by key creation.

## Have we considered potential risks?

This is a medium risk change as we might delete keys that should not be deleted. 

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
