### PR TITLE
To use bucketssmslookup in riffraff 

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -31,7 +31,7 @@ deployments:
     type: aws-lambda
     parameters:
       fileName: gibbons.jar
-      bucket: content-api-dist
+      bucketSsmLookup: true
       functions:
         CODE:
           name: gibbons-unverified-cleanup-CODE


### PR DESCRIPTION
Using `bucketssmlookup` to true instead of explicit bucket name inside riffraff file. recommended by DevX team.

To fix deploy warning as shown in screenshot below :

![image](https://user-images.githubusercontent.com/17780995/231719821-641edc1a-055a-4bde-af61-74dba3da680f.png)

Tested on CODE deployment and result is now no warnings on the page, as shown in screenshot below:

<img width="1263" alt="image" src="https://user-images.githubusercontent.com/17780995/231720638-820f4518-f16b-45ad-b5d7-dac2f4e36079.png">



