### PR TITLE
Java 11 build and runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: corretto
-          java-version: 8
+          java-version: 11
           cache: sbt
 
       - name: Build and test

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file("."))
     inThisBuild(
       List(
         organization := "com.gu",
-        scalaVersion := "2.12.5",
+        scalaVersion := "2.12.18",
         scalacOptions ++= Seq(
           "-Ypartial-unification",
           "-language:higherKinds",

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -43,7 +43,7 @@ Globals:
         CodeUri:
             Bucket: content-api-dist
             Key: !Sub ${Stack}/${Stage}/${App}-reminder/${App}.jar
-        MemorySize: 384
+        MemorySize: 512
         Runtime: java11
         Timeout: 100
 Resources:

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -44,7 +44,7 @@ Globals:
             Bucket: content-api-dist
             Key: !Sub ${Stack}/${Stage}/${App}-reminder/${App}.jar
         MemorySize: 384
-        Runtime: java8
+        Runtime: java11
         Timeout: 100
 Resources:
     LambdaRole:

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.0
+sbt.version=1.9.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.github.gseitz" % "sbt-release"  % "1.0.8")
-addSbtPlugin("com.typesafe.sbt"  % "sbt-twirl"    % "1.5.1")
+addSbtPlugin("com.typesafe.play"  % "sbt-twirl"    % "1.5.2")
 addSbtPlugin("com.eed3si9n"      % "sbt-assembly" % "0.14.6")
 addSbtPlugin("com.geirsson"      % "sbt-scalafmt" % "1.5.1")


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Nudge build and runtime to Java 11.
We want to remove occurrences of projects which require developers to maintain a Java 8 stack to work with them.

## How to test

Trigger dry runs of CODE lambdas.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
