### PR TITLE
Gradually decrease inactivity period

### DIFF
--- a/src/main/scala/com.gu.gibbons/config/Settings.scala
+++ b/src/main/scala/com.gu.gibbons/config/Settings.scala
@@ -31,19 +31,7 @@ case class HttpSettings(
 )
 
 object Settings {
-  // We want to gradually decrease the inactivity period from 30 months to 3 months to avoid suddenly having 15k exipiring keys.
-  // This code is meant to run from September 26, 2023 to October 22, 2023 after which lines 37 to 44 should be removed
-  def inactivityPeriod = {
-    val now =  java.time.LocalDate.now
-    val dayOfMonth = now.getDayOfMonth
-    val month = now.getMonth.getValue
-
-    if (dayOfMonth >= 26 && month == 9) {
-      Period.ofMonths(30 - dayOfMonth + 25)
-    } else if (now.getDayOfMonth <= 22 && month == 10) {
-      Period.ofMonths(30 - dayOfMonth - 5)
-    } else Period.ofMonths(3)
-  }
+  val inactivityPeriod = Period.ofMonths(30)
   val extensionGracePeriod = Period.ofWeeks(2)
   val verificationGracePeriod = Period.ofDays(1)
   val reminderSubject = "Your Content API keys are about to expire"

--- a/src/main/scala/com.gu.gibbons/config/Settings.scala
+++ b/src/main/scala/com.gu.gibbons/config/Settings.scala
@@ -5,7 +5,7 @@ import cats.data.{Validated, ValidatedNel}
 import cats.implicits._
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.regions.Regions
-import java.time.{Period, Instant}
+import java.time.Period
 import scala.collection.JavaConverters._
 import scala.util.Try
 import model.Email
@@ -32,7 +32,7 @@ case class HttpSettings(
 
 object Settings {
   // We want to gradually decrease the inactivity period from 30 months to 3 months to avoid suddenly having 15k exipiring keys.
-  // This code is meant to run from September 26, 2023 to October 22, 2023 after which lines 27 to 44 should be removed
+  // This code is meant to run from September 26, 2023 to October 22, 2023 after which lines 37 to 44 should be removed
   def inactivityPeriod = {
     val now =  java.time.LocalDate.now
     val dayOfMonth = now.getDayOfMonth

--- a/src/main/twirl/deleted.scala.html
+++ b/src/main/twirl/deleted.scala.html
@@ -7,7 +7,7 @@
         <p>Dear @to.name,
           <br>
           <br>
-          GDPR requires the Guardian to delete API keys that are over 30 months old, unless the user confirms that they wish to keep using their key.</p>
+          GDPR requires the Guardian to delete API keys periodically, unless the user confirms that they wish to keep using their key.</p>
         <p>Two weeks ago, we sent you an email asking whether you were still using your API key, but we haven't heard back from you. As requested by the legislation, your key has been deleted and can no longer be used to access the Guardian's Open Platform.</p>
       </td>
     </tr>

--- a/src/main/twirl/deleted.scala.html
+++ b/src/main/twirl/deleted.scala.html
@@ -7,7 +7,7 @@
         <p>Dear @to.name,
           <br>
           <br>
-          GDPR requires the Guardian to delete API keys periodically, unless the user confirms that they wish to keep using their key.</p>
+          Data protection laws require the Guardian to limit the amount of user data we hold. Unused API keys are deleted periodically, unless the user confirms that they wish to keep using their key..</p>
         <p>Two weeks ago, we sent you an email asking whether you were still using your API key, but we haven't heard back from you. As requested by the legislation, your key has been deleted and can no longer be used to access the Guardian's Open Platform.</p>
       </td>
     </tr>

--- a/src/main/twirl/reminder.scala.html
+++ b/src/main/twirl/reminder.scala.html
@@ -9,7 +9,8 @@
         <p>Dear @user.name,
           <br>
           <br>
-          GDPR requires the Guardian to delete API keys periodically, unless the user confirms that they wish to keep using their key. If you wish to retain access to the Guardian's Content API, please confirm <a href="@gen.extendKey(key)">here</a>, or by copy-pasting the following URL in your browser:</p>
+          Data protection laws require the Guardian to limit the amount of user data we hold. Unused API keys are deleted periodically, unless the user confirms that they wish to keep using their key.
+          If you wish to retain access to the Guardian's Content API, please confirm <a href="@gen.extendKey(key)">here</a>, or by copy-pasting the following URL in your browser:</p>
           
         <p>@gen.extendKey(key)</p>
 

--- a/src/main/twirl/reminder.scala.html
+++ b/src/main/twirl/reminder.scala.html
@@ -9,7 +9,7 @@
         <p>Dear @user.name,
           <br>
           <br>
-          GDPR requires the Guardian to delete API keys that are over 30 months old, unless the user confirms that they wish to keep using their key. If you wish to retain access to the Guardian's Content API, please confirm <a href="@gen.extendKey(key)">here</a>, or by copy-pasting the following URL in your browser:</p>
+          GDPR requires the Guardian to delete API keys periodically, unless the user confirms that they wish to keep using their key. If you wish to retain access to the Guardian's Content API, please confirm <a href="@gen.extendKey(key)">here</a>, or by copy-pasting the following URL in your browser:</p>
           
         <p>@gen.extendKey(key)</p>
 


### PR DESCRIPTION
## What does this change?

Syndication have asked us to decrease developer key inactivity period from 30 months to 3 months. If introduced immediately, this change will result in over 15k keys "in debt", which will be challenging to process and send emails to. 

This change proposes decreasing that inactivity period gradually over the course of the next month. Which will only add to Gibbons the burden of one month worth of keys at a time.

## How to test

Can be tested in DRY_RUN.

