### PR TITLE
Update to actions-riff-raff@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
       contents: read
       checks: write
       issues: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v3
@@ -33,16 +34,14 @@ jobs:
         if: always() #runs even if there is a test failure
         with:
           files: junit-tests/*.xml
-      - uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          aws-region: eu-west-1
-          role-to-assume: ${{secrets.GU_RIFF_RAFF_ROLE_ARN}}
 
-      - uses: guardian/actions-riff-raff@v2
+      - uses: guardian/actions-riff-raff@v4
         with:
           configPath: riff-raff.yaml
           projectName: Content Platforms::gibbons
           buildNumberOffset: 272
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           contentDirectories: |
             gibbons-reminder:
               - target/scala-2.12/gibbons.jar


### PR DESCRIPTION
Saw a recent email from DevX about upgrading, figured I’d do it quickly. Version 4 means we can get rid of the AWS credentials step and leaves us less vulnerable to credentials access by malicious dependencies

See [the release notes for version 4](https://github.com/guardian/actions-riff-raff/releases/tag/v4) and [those for version 3](https://github.com/guardian/actions-riff-raff/releases/tag/v3.0.0) (the latter necessary because we’re coming from version 2.)