### PR TITLE
Remove unused `sbt-release` plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,3 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release"  % "1.0.8")
 addSbtPlugin("com.typesafe.play"  % "sbt-twirl"    % "1.5.2")
 addSbtPlugin("com.eed3si9n"      % "sbt-assembly" % "0.14.6")
 addSbtPlugin("com.geirsson"      % "sbt-scalafmt" % "1.5.1")


### PR DESCRIPTION
Although present in the initial commit of this project (ee4465c31efe66bb613d802e3e9a385a8fb46710), I don't think this repo has ever publish Maven artifacts, and so doesn't need the `sbt-release` plugin?
